### PR TITLE
Refactor type hints to modern Python style

### DIFF
--- a/codfreq/align.py
+++ b/codfreq/align.py
@@ -12,15 +12,9 @@ from collections import defaultdict
 from pathlib import Path
 from typing import (
     TextIO,
-    Iterable,
-    Generator,
-    List,
-    Tuple,
-    DefaultDict,
-    Set,
-    Optional,
     Annotated,
 )
+from collections.abc import Iterable, Generator
 
 import rich
 import typer
@@ -76,7 +70,7 @@ def find_paired_marker(text1: str, text2: str) -> int:
 
 
 def find_paired_fastq_patterns(
-    filenames: List[str],
+    filenames: list[str],
     autopairing: bool
 ) -> Generator[PairedFASTQ, None, None]:
     """Smartly find paired FASTQ file patterns
@@ -104,21 +98,21 @@ def find_paired_fastq_patterns(
     diffcount: int
     diffoffset: int
     reverse: int
-    pattern: Tuple[
+    pattern: tuple[
         str,  # delimiter
         int,  # diffoffset
         int,  # pos_paired_marker
         int,  # reverse
     ]
-    pairs: List[Tuple[str, str]]
-    patterns: DefaultDict[
-        Tuple[
+    pairs: list[tuple[str, str]]
+    patterns: defaultdict[
+        tuple[
             str,  # delimiter
             int,  # diffoffset
             int,  # pos_paired_marker
             int,  # reverse
         ],
-        List[Tuple[str, str]]
+        list[tuple[str, str]]
     ] = defaultdict(list)
     if autopairing:
         for fn1, fn2 in combinations(filenames, 2):
@@ -127,8 +121,8 @@ def find_paired_fastq_patterns(
             for delimiter in FILENAME_DELIMITERS:
                 if delimiter not in fn1 or delimiter not in fn2:
                     continue
-                chunks1: List[str] = fn1.split(delimiter)
-                chunks2: List[str] = fn2.split(delimiter)
+                chunks1: list[str] = fn1.split(delimiter)
+                chunks2: list[str] = fn2.split(delimiter)
                 if len(chunks1) != len(chunks2):
                     continue
                 for reverse in range(2):
@@ -161,11 +155,11 @@ def find_paired_fastq_patterns(
                             pos_paired_marker,
                             reverse
                         )].append((fn1, fn2))
-    covered: Set[str] = set()
+    covered: set[str] = set()
     if autopairing:
         for pattern, pairs in sorted(
                 patterns.items(), key=lambda p: (-len(p[1]), -p[0][3])):
-            known: Set[str] = set()
+            known: set[str] = set()
             invalid = False
             for left, right in pairs:
                 if left in covered or right in covered:
@@ -190,7 +184,7 @@ def find_paired_fastq_patterns(
                         'n': 2
                     }
     if len(filenames) > len(covered):
-        remains: List[str] = sorted(set(filenames) - covered)
+        remains: list[str] = sorted(set(filenames) - covered)
         pattern = ('', -1, -1, -1)
         for left in remains:
             yield {
@@ -228,7 +222,7 @@ def find_paired_fastqs(
                 workdir
             )
     else:
-        pairinfo_list: List[PairedFASTQ] = []
+        pairinfo_list: list[PairedFASTQ] = []
         for dirpath, _, filenames in os.walk(workdir, followlinks=True):
             filenames = [
                 fn for fn in filenames
@@ -406,8 +400,8 @@ def align_with_profile(
     profile: Profile,
     log_format: LogFormat,
     fastp_config: fastp.FASTPConfig,
-    cutadapt_config: Optional[cutadapt.CutadaptConfig],
-    ivar_trim_config: Optional[ivar.TrimConfig]
+    cutadapt_config: cutadapt.CutadaptConfig | None,
+    ivar_trim_config: ivar.TrimConfig | None
 ) -> None:
     """Align reads to references defined in the profile.
 
@@ -438,7 +432,7 @@ def align_with_profile(
             refname = config['fragmentName']
             refseq = config['refSequence']
             with open(refpath, 'w') as fp:
-                fp.write('>{}\n{}\n\n'.format(refname, refseq))
+                fp.write(f'>{refname}\n{refseq}\n\n')
 
             orig_bamfile = name_bamfile(
                 paired_fastq['name'],
@@ -519,13 +513,13 @@ def align(
     fastp_config: fastp.FASTPConfig = fastp.load_config(
         str(workdir / 'fastp-config.json')
     )
-    cutadapt_config: Optional[cutadapt.CutadaptConfig] = cutadapt.load_config(
+    cutadapt_config: cutadapt.CutadaptConfig | None = cutadapt.load_config(
         str(workdir / 'cutadapt-config.json'),
         adapter3_path=str(workdir / 'primers3.fa'),
         adapter5_path=str(workdir / 'primers5.fa'),
         adapter53_path=str(workdir / 'primers53.fa')
     )
-    ivar_trim_config: Optional[ivar.TrimConfig] = ivar.load_trim_config(
+    ivar_trim_config: ivar.TrimConfig | None = ivar.load_trim_config(
         str(workdir / 'ivar-trim-config.json'),
         str(workdir / 'primers.bed')
     )

--- a/codfreq/cmdwrappers/base.py
+++ b/codfreq/cmdwrappers/base.py
@@ -1,6 +1,6 @@
 import sys
 from subprocess import Popen, PIPE
-from typing import List, Tuple, Callable
+from collections.abc import Callable
 
 import rich
 import typer
@@ -10,7 +10,7 @@ ALIGN_FUNCTIONS = {}
 AUTOREMOVE_CONTAINERS = False
 
 
-def execute(command: List[str]) -> Tuple[str, str]:
+def execute(command: list[str]) -> tuple[str, str]:
     """Execute a subprocess and capture its output.
 
     :param command: Command and arguments to run.
@@ -54,7 +54,7 @@ def align_func(name: str) -> Callable:
     return wrapper
 
 
-def get_programs() -> List[str]:
+def get_programs() -> list[str]:
     return sorted(ALIGN_FUNCTIONS.keys())
 
 

--- a/codfreq/cmdwrappers/bowtie2.py
+++ b/codfreq/cmdwrappers/bowtie2.py
@@ -2,11 +2,10 @@
 
 import os
 import re
-from typing import List, Dict, Optional, Tuple
 
 from .base import execute, refinit_func, align_func
 
-BOWTIE2_ARGS: List[str] = [
+BOWTIE2_ARGS: list[str] = [
     '--local',
     '--threads', '3',
     '--rdg', '15,3',  # read gap open, extend penalties
@@ -21,11 +20,10 @@ BOWTIE2_ARGS: List[str] = [
 def bowtie2_refinit(refseq: str) -> None:
     refpath: str
     ext: str
-    suffix: str
     refdir: str
     refname: str
     refpath, ext = os.path.splitext(refseq)
-    suffixes: Tuple[str, ...] = (
+    suffixes: tuple[str, ...] = (
         '1.bt2',
         '2.bt2',
         '3.bt2',
@@ -51,14 +49,14 @@ def bowtie2_align(
     fastq1: str,
     fastq2: str,
     sam: str
-) -> Dict[str, float]:
+) -> dict[str, float]:
     refpath: str
     refdir: str
     refname: str
     logs: str
     refpath, _ = os.path.splitext(refseq)
     refdir, refname = os.path.split(refpath)
-    command: List[str] = [
+    command: list[str] = [
         'bowtie2',
         *BOWTIE2_ARGS,
         '-x', refpath,
@@ -69,7 +67,7 @@ def bowtie2_align(
         command.extend(['-U', fastq2])
     logs, _ = execute(command)
     overall_rate: float = -1.
-    overall_rate_match: Optional[re.Match] = re.search(
+    overall_rate_match: re.Match | None = re.search(
         r'\n(\d+\.\d+)% overall alignment rate',
         logs)
     if overall_rate_match:

--- a/codfreq/cmdwrappers/cutadapt.py
+++ b/codfreq/cmdwrappers/cutadapt.py
@@ -1,19 +1,19 @@
 import os
 import json
 from subprocess import Popen, PIPE
-from typing import List, Optional, TypedDict
+from typing import TypedDict
 
 from .base import raise_on_proc_error
 
 
 class CutadaptConfig(TypedDict, total=False):
-    adapter3: Optional[str]
-    adapter5: Optional[str]
-    adapter53: Optional[str]
-    error_rate: Optional[float]
-    no_indels: Optional[bool]
-    times: Optional[int]
-    min_overlap: Optional[int]
+    adapter3: str | None
+    adapter5: str | None
+    adapter53: str | None
+    error_rate: float | None
+    no_indels: bool | None
+    times: int | None
+    min_overlap: int | None
 
 
 def load_config(
@@ -21,7 +21,7 @@ def load_config(
     adapter3_path: str,
     adapter5_path: str,
     adapter53_path: str
-) -> Optional[CutadaptConfig]:
+) -> CutadaptConfig | None:
     if os.path.isfile(config_path):
         config: CutadaptConfig
         with open(config_path) as fp:
@@ -40,15 +40,15 @@ def load_config(
 def cutadapt(
     merged_fastq_in: str,
     merged_fastq_out: str,
-    adapter3: Optional[str] = None,
-    adapter5: Optional[str] = None,
-    adapter53: Optional[str] = None,
-    error_rate: Optional[float] = None,
-    no_indels: Optional[bool] = None,
-    times: Optional[int] = None,
-    min_overlap: Optional[int] = None
+    adapter3: str | None = None,
+    adapter5: str | None = None,
+    adapter53: str | None = None,
+    error_rate: float | None = None,
+    no_indels: bool | None = None,
+    times: int | None = None,
+    min_overlap: int | None = None
 ) -> None:
-    command: List[str] = ['cutadapt', '-j', '0']
+    command: list[str] = ['cutadapt', '-j', '0']
     if adapter3 is not None:
         command.extend(['-a', adapter3])
     if adapter5 is not None:

--- a/codfreq/cmdwrappers/fastp.py
+++ b/codfreq/cmdwrappers/fastp.py
@@ -1,28 +1,28 @@
 import os
 import json
 from subprocess import Popen, PIPE
-from typing import List, Optional, TypedDict
+from typing import TypedDict
 import multiprocessing
 
 from .base import raise_on_proc_error
 
-THREADS = '{}'.format(multiprocessing.cpu_count() // 2 + 1)
+THREADS = f'{multiprocessing.cpu_count() // 2 + 1}'
 
 
 class FASTPConfig(TypedDict, total=False):
-    include_unmerged: Optional[bool]
-    qualified_quality_phred: Optional[int]
-    unqualified_percent_limit: Optional[int]
-    n_base_limit: Optional[int]
-    average_qual: Optional[int]
-    length_required: Optional[int]
-    length_limit: Optional[int]
-    adapter_sequence: Optional[str]
-    adapter_sequence_r2: Optional[str]
-    disable_adapter_trimming: Optional[bool]
-    disable_trim_poly_g: Optional[bool]
-    disable_quality_filtering: Optional[bool]
-    disable_length_filtering: Optional[bool]
+    include_unmerged: bool | None
+    qualified_quality_phred: int | None
+    unqualified_percent_limit: int | None
+    n_base_limit: int | None
+    average_qual: int | None
+    length_required: int | None
+    length_limit: int | None
+    adapter_sequence: str | None
+    adapter_sequence_r2: str | None
+    disable_adapter_trimming: bool | None
+    disable_trim_poly_g: bool | None
+    disable_quality_filtering: bool | None
+    disable_length_filtering: bool | None
 
 
 def load_config(config_path: str) -> FASTPConfig:
@@ -36,23 +36,23 @@ def load_config(config_path: str) -> FASTPConfig:
 
 def fastp(
     fastq1in: str,
-    fastq2in: Optional[str],
+    fastq2in: str | None,
     fastq_merged_out: str,
-    include_unmerged: Optional[bool] = False,
-    qualified_quality_phred: Optional[int] = None,
-    unqualified_percent_limit: Optional[int] = None,
-    n_base_limit: Optional[int] = None,
-    average_qual: Optional[int] = None,
-    length_required: Optional[int] = None,
-    length_limit: Optional[int] = None,
-    disable_adapter_trimming: Optional[bool] = False,
-    disable_trim_poly_g: Optional[bool] = False,
-    disable_quality_filtering: Optional[bool] = False,
-    disable_length_filtering: Optional[bool] = False,
-    adapter_sequence: Optional[str] = None,
-    adapter_sequence_r2: Optional[str] = None
+    include_unmerged: bool | None = False,
+    qualified_quality_phred: int | None = None,
+    unqualified_percent_limit: int | None = None,
+    n_base_limit: int | None = None,
+    average_qual: int | None = None,
+    length_required: int | None = None,
+    length_limit: int | None = None,
+    disable_adapter_trimming: bool | None = False,
+    disable_trim_poly_g: bool | None = False,
+    disable_quality_filtering: bool | None = False,
+    disable_length_filtering: bool | None = False,
+    adapter_sequence: str | None = None,
+    adapter_sequence_r2: str | None = None
 ) -> None:
-    command: List[str] = [
+    command: list[str] = [
         'fastp',
         '-w', str(THREADS),
         '-i', fastq1in

--- a/codfreq/cmdwrappers/ivar.py
+++ b/codfreq/cmdwrappers/ivar.py
@@ -2,26 +2,26 @@ import os
 import json
 from subprocess import Popen, PIPE
 from tempfile import NamedTemporaryFile
-from typing import List, Optional, TypedDict
+from typing import TypedDict
 import multiprocessing
 
 from .base import execute, raise_on_proc_error
 
-THREADS = '{}'.format(multiprocessing.cpu_count() // 2 + 1)
+THREADS = f'{multiprocessing.cpu_count() // 2 + 1}'
 
 
 class TrimConfig(TypedDict, total=False):
-    primers_bed: Optional[str]
-    min_length: Optional[int]
-    min_quality: Optional[int]
-    sliding_window_width: Optional[int]
-    include_reads_with_no_primers: Optional[bool]
+    primers_bed: str | None
+    min_length: int | None
+    min_quality: int | None
+    sliding_window_width: int | None
+    include_reads_with_no_primers: bool | None
 
 
 def load_trim_config(
     config_path: str,
     primers_bed: str
-) -> Optional[TrimConfig]:
+) -> TrimConfig | None:
     if os.path.isfile(config_path):
         config: TrimConfig
         with open(config_path) as fp:
@@ -36,15 +36,15 @@ def load_trim_config(
 def trim(
     input_bam: str,
     output_bam: str,
-    primers_bed: Optional[str] = None,
-    min_length: Optional[int] = None,
-    min_quality: Optional[int] = None,
-    sliding_window_width: Optional[int] = None,
-    include_reads_with_no_primers: Optional[bool] = False
+    primers_bed: str | None = None,
+    min_length: int | None = None,
+    min_quality: int | None = None,
+    sliding_window_width: int | None = None,
+    include_reads_with_no_primers: bool | None = False
 ) -> None:
     basedir, filename = os.path.split(input_bam)
 
-    command: List[str] = [
+    command: list[str] = [
         'ivar', 'trim',
         '-i', input_bam
     ]

--- a/codfreq/cmdwrappers/minimap2.py
+++ b/codfreq/cmdwrappers/minimap2.py
@@ -1,12 +1,11 @@
 from subprocess import Popen, PIPE
-from typing import List, Dict
 import multiprocessing
 
 from .base import execute, raise_on_proc_error, refinit_func, align_func
 
-THREADS = '{}'.format(multiprocessing.cpu_count() // 2 + 1)
+THREADS = f'{multiprocessing.cpu_count() // 2 + 1}'
 
-MINIMAP2_ARGS: List[str] = [
+MINIMAP2_ARGS: list[str] = [
     '-A', '2',        # matching score [2]
     '-B', '4',        # mismatch penalty [4]
     '-O', '4,24',     # gap open penalty [4,24]
@@ -32,12 +31,12 @@ def minimap2_align(
     fastq1: str,
     fastq2: str,
     bam: str
-) -> Dict[str, float]:
+) -> dict[str, float]:
     out_sam2bam: str
     err_sam2bam: str
     out_samidx: str
     err_samidx: str
-    command: List[str] = [
+    command: list[str] = [
         'minimap2',
         *MINIMAP2_ARGS,
         '-a', refseq, fastq1

--- a/codfreq/cmdwrappers/pigz.py
+++ b/codfreq/cmdwrappers/pigz.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, ByteString
+from collections.abc import ByteString
 from subprocess import Popen, PIPE
 
 
@@ -6,11 +6,11 @@ def compress(
     data: ByteString,
     compresslevel: int = 9,
     *,
-    mtime: Optional[float] = None
+    mtime: float | None = None
 ) -> bytes:
     out: bytes
     error: bytes
-    cmd: List[str] = ['pigz', f'-{compresslevel}', '-c']
+    cmd: list[str] = ['pigz', f'-{compresslevel}', '-c']
     if mtime:
         cmd.extend(['-M', f'{mtime}'])
     proc: Popen = Popen(
@@ -29,7 +29,7 @@ def compress(
 def decompress(data: ByteString) -> bytes:
     out: bytes
     error: bytes
-    cmd: List[str] = ['pigz', '-d', '-c']
+    cmd: list[str] = ['pigz', '-d', '-c']
     proc: Popen = Popen(
         cmd,
         stdin=PIPE,

--- a/codfreq/codfreq_types.py
+++ b/codfreq/codfreq_types.py
@@ -1,4 +1,4 @@
-from typing import Optional, TypedDict, Tuple, List, Dict, Union, Literal
+from typing import TypedDict, Literal
 
 FASTQFileName = str
 Header = str
@@ -12,12 +12,12 @@ CodonText = MultiNAText
 AAChar = int
 MultiAAText = bytes
 
-NAPosRange = Tuple[NAPos, NAPos]
+NAPosRange = tuple[NAPos, NAPos]
 
 
 class PairedFASTQ(TypedDict):
     name: Header
-    pair: Tuple[FASTQFileName, Optional[FASTQFileName]]
+    pair: tuple[FASTQFileName, FASTQFileName | None]
     n: int
 
 
@@ -34,34 +34,31 @@ class MainFragmentConfig(TypedDict):
 class CodonAlignmentConfig(TypedDict, total=False):
     relRefStart: NAPos
     relRefEnd: NAPos
-    windowSize: Optional[AAPos]
-    minGapDistance: Optional[NAPos]
-    relGapPlacementScore: Optional[str]
+    windowSize: AAPos | None
+    minGapDistance: NAPos | None
+    relGapPlacementScore: str | None
 
 
 class DerivedFragmentConfig(TypedDict, total=False):
     fragmentName: Header
     fromFragment: Header
     refSequence: None
-    geneName: Optional[GeneText]
-    refRanges: List[NAPosRange]
-    codonAlignment: Optional[Union[
-        Literal[False], List[CodonAlignmentConfig]
-    ]]
+    geneName: GeneText | None
+    refRanges: list[NAPosRange]
+    codonAlignment: None | (
+        Literal[False] | list[CodonAlignmentConfig]
+    )
 
 
-FragmentConfig = Union[
-    MainFragmentConfig,
-    DerivedFragmentConfig
-]
+FragmentConfig = MainFragmentConfig | DerivedFragmentConfig
 
 
 class SequenceAssemblyConfig(TypedDict):
-    name: Optional[str]
-    geneName: Optional[str]
-    fromFragment: Optional[str]
-    refStart: Optional[int]
-    refEnd: Optional[int]
+    name: str | None
+    geneName: str | None
+    fromFragment: str | None
+    refStart: int | None
+    refEnd: int | None
 
 
 class NARegionConfig(TypedDict):
@@ -80,8 +77,8 @@ class RegionalConsensus(TypedDict):
 
 class Profile(TypedDict):
     version: str
-    fragmentConfig: List[FragmentConfig]
-    sequenceAssemblyConfig: List[SequenceAssemblyConfig]
+    fragmentConfig: list[FragmentConfig]
+    sequenceAssemblyConfig: list[SequenceAssemblyConfig]
 
 
 class CodFreqRow(TypedDict):
@@ -95,6 +92,6 @@ class CodFreqRow(TypedDict):
 
 #                                 refStart refEnd
 #                                     v      v
-FragmentInterval = Tuple[List[Tuple[NAPos, NAPos]], Header]
+FragmentInterval = tuple[list[tuple[NAPos, NAPos]], Header]
 
-RefAAs = Dict[AAPos, MultiAAText]
+RefAAs = dict[AAPos, MultiAAText]

--- a/codfreq/codonalign_consensus.py
+++ b/codfreq/codonalign_consensus.py
@@ -10,15 +10,9 @@ from postalign.models.sequence import (
 )
 from operator import itemgetter
 from typing import (
-    Optional,
-    List,
-    Dict,
-    Tuple,
-    Iterator,
-    Union,
-    Literal,
-    Counter
+    Literal
 )
+from collections import Counter
 
 from .sam2codfreq_types import CodonCounterByFragPos
 from .codfreq_types import (
@@ -27,7 +21,6 @@ from .codfreq_types import (
     NAPosRange,
     CodonText,
     Header,
-    CodFreqRow,
     MainFragmentConfig,
     DerivedFragmentConfig,
     CodonAlignmentConfig
@@ -46,7 +39,7 @@ def get_sequence_obj(
     seqid: int
 ) -> Sequence:
     return Sequence(
-        header='seq{}'.format(seqid),
+        header=f'seq{seqid}',
         description='',
         seqtext=NAPosition.init_from_bytes(seq_bytearray),
         seqid=seqid,
@@ -61,7 +54,7 @@ def get_sequence_obj(
 @cython.returns(int)
 def aapos_to_napos(
     aapos: AAPos,
-    refranges: List[NAPosRange]
+    refranges: list[NAPosRange]
 ) -> NAPos:
     max_rel_napos = 0
     for start, end in refranges:
@@ -81,11 +74,11 @@ def assemble_alignment(
     codonstat_by_fragpos: CodonCounterByFragPos,
     refseq: bytearray,
     fragment: DerivedFragmentConfig
-) -> Tuple[
-    Optional[Sequence],
-    Optional[Sequence],
-    Optional[AAPos],
-    Optional[AAPos]
+) -> tuple[
+    Sequence | None,
+    Sequence | None,
+    AAPos | None,
+    AAPos | None
 ]:
     aapos: AAPos
     napos: NAPos
@@ -93,9 +86,9 @@ def assemble_alignment(
     cons_codon: bytearray
     cons_codon_bytes: bytes
     cons_codon_size: int
-    codons: Optional[Counter[CodonText]]
+    codons: Counter[CodonText] | None
     fragment_name: Header = fragment['fragmentName']
-    frag_refranges: List[NAPosRange] = fragment['refRanges']
+    frag_refranges: list[NAPosRange] = fragment['refRanges']
     frag_refseq: bytearray = bytearray()
     frag_queryseq: bytearray = bytearray()
     refsize: int = sum(end - start + 1 for start, end in frag_refranges)
@@ -147,32 +140,30 @@ def codonalign_consensus(
     codonstat_by_fragpos: CodonCounterByFragPos,
     qualities_by_fragpos: CodonCounterByFragPos,
     ref: MainFragmentConfig,
-    fragments: List[DerivedFragmentConfig],
-) -> Tuple[CodonCounterByFragPos, CodonCounterByFragPos]:
+    fragments: list[DerivedFragmentConfig],
+) -> tuple[CodonCounterByFragPos, CodonCounterByFragPos]:
+    """Derive codon consensus for aligned fragments."""
+
     fragment_name: Header
     fragment: DerivedFragmentConfig
-    frag_refseq_obj: Optional[Sequence]
-    frag_queryseq_obj: Optional[Sequence]
-    first_aa: Optional[AAPos]
-    last_aa: Optional[AAPos]
-    seq_ref_start: NAPos
+    frag_refseq_obj: Sequence | None
+    frag_queryseq_obj: Sequence | None
+    first_aa: AAPos | None
+    last_aa: AAPos | None
     aapos0: AAPos
     aapos: AAPos
     refstart: NAPos
     refend: NAPos
-    refcodon: List[NAPosition]
-    querycodon: List[NAPosition]
-    codons: Optional[Counter[CodonText]]
-    cdfs: Iterator[CodFreqRow]
-    cdf_list: List[CodFreqRow]
-    codon: CodonText
+    refcodon: list[NAPosition]
+    querycodon: list[NAPosition]
+    codons: Counter[CodonText] | None
 
     refseq: bytearray = bytearray(ref['refSequence'], ENCODING)
     for fragment in fragments:
         fragment_name = fragment['fragmentName']
-        codon_align_config: Optional[
-            Union[Literal[False], List[CodonAlignmentConfig]]
-        ] = fragment.get('codonAlignment')
+        codon_align_config: None | (
+            Literal[False] | list[CodonAlignmentConfig]
+        ) = fragment.get('codonAlignment')
 
         if codon_align_config is False:
             # skip this gene if explicitly defined codonAlignment=False
@@ -218,8 +209,8 @@ def codonalign_consensus(
             window_size = cda_config.get(
                 'windowSize'
             ) or CODON_ALIGN_WINDOW_SIZE
-            gap_placement_score: Dict[
-                int, Dict[Tuple[int, int], int]
+            gap_placement_score: dict[
+                int, dict[tuple[int, int], int]
             ] = parse_gap_placement_score(
                 cda_config.get('relGapPlacementScore') or '')
 

--- a/codfreq/codonutils.py
+++ b/codfreq/codonutils.py
@@ -1,4 +1,3 @@
-from typing import Dict, List, Set
 from .codfreq_types import (
     CodonText,
     AAChar, MultiAAText,
@@ -6,7 +5,7 @@ from .codfreq_types import (
 )
 
 
-CODON_TABLE: Dict[CodonText, MultiAAText] = {
+CODON_TABLE: dict[CodonText, MultiAAText] = {
     b'TTT': b'F',
     b'TTC': b'F',
     b'TTA': b'L',
@@ -89,12 +88,12 @@ CODON_TABLE: Dict[CodonText, MultiAAText] = {
     b'TAG': b'*',
 }
 
-REVERSE_CODON_TABLE: Dict[AAChar, List[CodonText]] = {}
+REVERSE_CODON_TABLE: dict[AAChar, list[CodonText]] = {}
 for codon, aa in CODON_TABLE.items():
     REVERSE_CODON_TABLE.setdefault(aa[0], []).append(codon)
 
 
-AMBIGUOUS_NAS: Dict[NAChar, MultiNAText] = {
+AMBIGUOUS_NAS: dict[NAChar, MultiNAText] = {
     ord(b'W'): b'AT',
     ord(b'S'): b'CG',
     ord(b'M'): b'AC',
@@ -118,12 +117,12 @@ def translate_codon(nas: MultiNAText) -> MultiAAText:
     nas = nas.replace(b'-', b'N')[:3]
     if nas in CODON_TABLE:
         return CODON_TABLE[nas]
-    aas: Set[int] = set()
+    aas: set[int] = set()
     for na0 in AMBIGUOUS_NAS.get(nas[0], nas[0:1]):
         for na1 in AMBIGUOUS_NAS.get(nas[1], nas[1:2]):
             for na2 in AMBIGUOUS_NAS.get(nas[2], nas[2:3]):
                 aas |= set(
                     CODON_TABLE[bytes([na0, na1, na2])]
                 )
-    CODON_TABLE[nas] = aas_text = bytes((sorted(aas)))
+    CODON_TABLE[nas] = aas_text = bytes(sorted(aas))
     return aas_text

--- a/codfreq/compress_codfreq.py
+++ b/codfreq/compress_codfreq.py
@@ -1,15 +1,11 @@
 import os
 import json
 from typing import (
-    Dict,
-    List,
-    Tuple,
     TextIO,
     BinaryIO,
-    Optional,
-    ByteString,
     Annotated,
 )
+from collections.abc import ByteString
 
 from pathlib import Path
 
@@ -27,17 +23,17 @@ app = typer.Typer(pretty_exceptions_enable=False)
 
 def find_codfreq_untrans_pairs(
     workdir: Path
-) -> List[Tuple[str, Optional[str]]]:
+) -> list[tuple[str, str | None]]:
     """Find paired CodFreq and untranslated JSON files.
 
     :param workdir: Directory to search.
     :returns: List of tuples mapping CodFreq paths to untranslated JSON paths.
     """
     key: str
-    untrans_json: Optional[str]
-    codfreq: Optional[str]
-    pair: Tuple[Optional[str], Optional[str]]
-    pairs: Dict[str, Tuple[Optional[str], Optional[str]]] = {}
+    untrans_json: str | None
+    codfreq: str | None
+    pair: tuple[str | None, str | None]
+    pairs: dict[str, tuple[str | None, str | None]] = {}
     for dirpath, _, filenames in os.walk(workdir, followlinks=True):
         for filename in filenames:
             untrans_json = codfreq = None
@@ -91,12 +87,12 @@ def compress_codfreq(
     :returns: None
     """
     codfreq: str
-    untrans: Optional[str]
+    untrans: str | None
     fp: BinaryIO
     text_fp: TextIO
     payload: ByteString
-    pairs: List[Tuple[
-        str, Optional[str]
+    pairs: list[tuple[
+        str, str | None
     ]] = find_codfreq_untrans_pairs(workdir)
     for codfreq, untrans in pairs:
         payload = bytearray(b'\xef\xbb\xbf')  # UTF-8 bom
@@ -110,7 +106,7 @@ def compress_codfreq(
                         .encode('UTF-8')
                     )
                 payload.extend(b'# --- untranslated regions end ---\n')
-        with open(codfreq, 'r', encoding='UTF-8-sig') as text_fp:
+        with open(codfreq, encoding='UTF-8-sig') as text_fp:
             payload.extend(text_fp.read().encode('UTF-8'))
         payload = pigz.compress(payload)
         with open(codfreq + '.gz', 'wb') as fp:

--- a/codfreq/fastareader.py
+++ b/codfreq/fastareader.py
@@ -1,10 +1,10 @@
-from typing import TextIO, List, Optional
+from typing import TextIO
 from .codfreq_types import Sequence
 
 
-def load(fp: TextIO) -> List[Sequence]:
-    sequences: List[Sequence] = []
-    header: Optional[str] = None
+def load(fp: TextIO) -> list[Sequence]:
+    sequences: list[Sequence] = []
+    header: str | None = None
     curseq: bytearray = bytearray()
     for line in fp:
         if line.startswith('>'):

--- a/codfreq/filename_helper.py
+++ b/codfreq/filename_helper.py
@@ -1,11 +1,10 @@
 import os
 import re
-from typing import Optional, Tuple
 
 from .codfreq_types import FASTQFileName, Header
 
-FnPair = Tuple[FASTQFileName, Optional[FASTQFileName]]
-Pattern = Tuple[
+FnPair = tuple[FASTQFileName, FASTQFileName | None]
+Pattern = tuple[
     str,  # delimiter
     int,  # diffoffset
     int,  # pos_paired_marker
@@ -17,6 +16,8 @@ def suggest_pair_name(
     fnpair: FnPair,
     pattern: Pattern
 ) -> str:
+    """Suggest a SAM/BAM base name from a pair of FASTQ files."""
+
     filename, _ = fnpair
     delimiter, offset, _, reverse = pattern
     dirpath, filename = os.path.split(filename)
@@ -39,6 +40,8 @@ def name_file(
     pattern: Pattern,
     suffix: str
 ) -> str:
+    """Generate a file name for a fragment pair."""
+
     return suggest_pair_name(fnpair, pattern) + suffix
 
 
@@ -47,21 +50,35 @@ def name_bamfile(
     ref_name: Header,
     is_trimmed: bool = True
 ) -> str:
+    """Return the BAM file name for a fragment."""
+
     return (
         '{}.{}.bam' if is_trimmed else '{}.{}.orig.bam'
     ).format(name, ref_name)
 
 
 def name_codfreq(name: str) -> str:
-    return '{}.codfreq'.format(name)
+    """Return the CodFreq file name for a fragment."""
+
+    return f'{name}.codfreq'
 
 
 def replace_ext(
         filename: str,
         toext: str,
-        fromext: Optional[str] = None,
+        fromext: str | None = None,
         name_only: bool = False
 ) -> str:
+    """Replace a file extension.
+
+    :param filename: Original file name.
+    :param toext: New extension including leading dot.
+    :param fromext: Expected original extension; if provided the last
+        characters are replaced without removing the existing extension.
+    :param name_only: If ``True`` only the base name is processed.
+    :returns: File name with the new extension.
+    """
+
     if name_only:
         filename = os.path.split(filename)[-1]
     if fromext:

--- a/codfreq/json_progress.py
+++ b/codfreq/json_progress.py
@@ -2,7 +2,7 @@ import sys
 import time
 import json
 
-from typing import Dict, Any
+from typing import Any
 
 
 class JsonProgress:
@@ -14,7 +14,7 @@ class JsonProgress:
     prev_ts: int
     ts_interval: int
     op: str
-    extras: Dict[str, Any]
+    extras: dict[str, Any]
 
     def __init__(
         self,

--- a/codfreq/make_response.py
+++ b/codfreq/make_response.py
@@ -3,7 +3,8 @@ import csv
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Tuple, Annotated
+from typing import Any, Annotated
+from collections.abc import Iterator
 
 import typer
 
@@ -16,7 +17,7 @@ def utcnow_text() -> str:
     return datetime.now(tz=timezone.utc).isoformat()
 
 
-def yield_codfreqs(workdir: Path) -> Iterator[Tuple[str, csv.DictReader]]:
+def yield_codfreqs(workdir: Path) -> Iterator[tuple[str, csv.DictReader]]:
     """Yield codfreq name and row iterator pairs from a directory.
 
     :param workdir: Directory containing CodFreq files.
@@ -31,7 +32,7 @@ def yield_codfreqs(workdir: Path) -> Iterator[Tuple[str, csv.DictReader]]:
             yield name, csv.DictReader(fp)
 
 
-def yield_untrans(workdir: Path) -> Iterator[Tuple[str, Any]]:
+def yield_untrans(workdir: Path) -> Iterator[tuple[str, Any]]:
     """Yield untranslated region data from a directory.
 
     :param workdir: Directory containing untranslated region files.
@@ -63,10 +64,10 @@ def make_response(
     :returns: None
     """
     uniqkey = path_prefix.split('/', 1)[-1]
-    codfreqs: Dict[str, List[Dict[str, Any]]] = {}
+    codfreqs: dict[str, list[dict[str, Any]]] = {}
     for name, rows in yield_codfreqs(workdir):
-        name = '{}.codfreq'.format(name)
-        gpmap: Dict[Tuple[str, int], Dict[str, Any]] = {}
+        name = f'{name}.codfreq'
+        gpmap: dict[tuple[str, int], dict[str, Any]] = {}
         for row in rows:
             gene = row['gene']
             pos = int(row['position'])

--- a/codfreq/paired_reads.py
+++ b/codfreq/paired_reads.py
@@ -3,25 +3,26 @@
 import pysam  # type: ignore
 from pysam import AlignedSegment  # type: ignore
 from collections import OrderedDict
-from typing import Tuple, List, Dict
 
 from .codfreq_types import Header
 
 __all__ = ['PairedReads', 'iter_paired_reads']
 
 
-PairedReads = Tuple[str, List[pysam.AlignedSegment]]
+PairedReads = tuple[str, list[pysam.AlignedSegment]]
 
 
 def iter_paired_reads(
     samfile: str
-) -> List[PairedReads]:
+) -> list[PairedReads]:
     idx: int
-    name: Header
+    name: Header | None
     read: AlignedSegment
-    paired_reads: Dict[str, List[AlignedSegment]] = OrderedDict()
+    paired_reads: dict[str, list[AlignedSegment]] = OrderedDict()
     with pysam.AlignmentFile(samfile, 'rb') as fp:
         for idx, read in enumerate(fp.fetch()):
             name = read.query_name
+            if name is None:
+                continue
             paired_reads.setdefault(name, []).append(read)
     return list(paired_reads.items())

--- a/codfreq/poscodons.py
+++ b/codfreq/poscodons.py
@@ -1,7 +1,7 @@
 import cython  # type: ignore
 import pysam  # type: ignore
 from pysam import AlignedSegment  # type: ignore
-from typing import List, DefaultDict, Tuple, Generator, Optional
+from collections.abc import Generator
 from collections import defaultdict
 
 from .codfreq_types import (
@@ -17,18 +17,20 @@ from .posnas import iter_single_read_posnas, PosNA
 
 #                                          Qual
 #                                           v
-PosCodon = Tuple[Header, AAPos, CodonText, int]
-BasePair = Tuple[AAPos, List[PosNA]]
+PosCodon = tuple[Header, AAPos, CodonText, int]
+BasePair = tuple[AAPos, list[PosNA]]
 
 
 @cython.cfunc
 @cython.inline
 @cython.returns(list)
 def group_posnas_by_napos(
-    posnas: List[PosNA]
-) -> List[Tuple[NAPos, List[PosNA]]]:
+    posnas: list[PosNA]
+) -> list[tuple[NAPos, list[PosNA]]]:
+    """Group PosNA entries by nucleotide position."""
+
     prev_pos: int = -1
-    by_napos: List[Tuple[NAPos, List[PosNA]]] = []
+    by_napos: list[tuple[NAPos, list[PosNA]]] = []
     for posna in posnas:
         if prev_pos == posna[0]:
             by_napos[-1][1].append(posna)
@@ -42,21 +44,21 @@ def group_posnas_by_napos(
 @cython.inline
 @cython.returns(list)
 def group_basepairs(
-    posnas: List[PosNA],
-    fragment_intervals: List[FragmentInterval]
-) -> List[Tuple[Header, List[BasePair]]]:
-    """Group same base-pair posnas (NA and ins) by its fragment AA position"""
+    posnas: list[PosNA],
+    fragment_intervals: list[FragmentInterval]
+) -> list[tuple[Header, list[BasePair]]]:
+    """Group positional nucleotides into codon base pairs."""
 
     napos: NAPos
-    na_and_ins: List[PosNA]
+    na_and_ins: list[PosNA]
     aapos: AAPos
-    frag_refranges: List[NAPosRange]
+    frag_refranges: list[NAPosRange]
     fragment_name: Header
 
-    posnas_by_napos: List[
-        Tuple[NAPos, List[PosNA]]
+    posnas_by_napos: list[
+        tuple[NAPos, list[PosNA]]
     ] = group_posnas_by_napos(posnas)
-    basepairs: DefaultDict[Header, List[BasePair]] = defaultdict(list)
+    basepairs: defaultdict[Header, list[BasePair]] = defaultdict(list)
 
     for napos, na_and_ins in posnas_by_napos:
         for frag_refranges, fragment_name in fragment_intervals:
@@ -76,13 +78,13 @@ def group_basepairs(
 @cython.inline
 @cython.returns(list)
 def find_intersected_fragments(
-    fragment_intervals: List[FragmentInterval],
+    fragment_intervals: list[FragmentInterval],
     read_refstart: NAPos,
     read_refend: NAPos
-) -> List[FragmentInterval]:
-    frag_refranges: List[NAPosRange]
+) -> list[FragmentInterval]:
+    frag_refranges: list[NAPosRange]
     fragment_name: Header
-    filtered: List[FragmentInterval] = []
+    filtered: list[FragmentInterval] = []
     for frag_refranges, fragment_name in fragment_intervals:
         if all(read_refend < start for start, _ in frag_refranges):
             continue
@@ -96,10 +98,10 @@ def find_intersected_fragments(
 @cython.inline
 @cython.returns(tuple)
 def get_comparable_codon(
-    codon_posnas: List[List[PosNA]]
-) -> Tuple[CodonText, bool]:
-    posnas: List[PosNA]
-    codon_chars: List[NAChar] = []
+    codon_posnas: list[list[PosNA]]
+) -> tuple[CodonText, bool]:
+    posnas: list[PosNA]
+    codon_chars: list[NAChar] = []
     num_bps: int = 0
 
     for posnas in codon_posnas:
@@ -115,8 +117,8 @@ def get_comparable_codon(
 @cython.inline
 @cython.returns(list)
 def group_codons(
-    basepairs: List[Tuple[Header, List[BasePair]]]
-) -> List[Tuple[Header, AAPos, List[List[PosNA]]]]:
+    basepairs: list[tuple[Header, list[BasePair]]]
+) -> list[tuple[Header, AAPos, list[list[PosNA]]]]:
     """Group base-pairs into complete codons
 
     A codon is represented by a nested list. The inner List[PosNA]
@@ -125,10 +127,8 @@ def group_codons(
     """
     aapos: AAPos
     fragment_name: Header
-    fragment_bps: List[BasePair]
-
-    bp: List[PosNA]
-    codons: List[Tuple[Header, AAPos, List[List[PosNA]]]] = []
+    fragment_bps: list[BasePair]
+    codons: list[tuple[Header, AAPos, list[list[PosNA]]]] = []
 
     for fragment_name, fragment_bps in basepairs:
         prev_aapos: AAPos = -1
@@ -145,29 +145,30 @@ def group_codons(
 @cython.inline
 @cython.returns(list)
 def posnas2poscodons(
-    posnas: List[PosNA],
-    fragment_intervals: List[FragmentInterval],
+    posnas: list[PosNA],
+    fragment_intervals: list[FragmentInterval],
     read_refstart: int,  # 1-based first aligned refpos
     read_refend: int,    # 1-based last aligned refpos
     site_quality_cutoff: int
-) -> List[PosCodon]:
-    meanq: List[int]
+) -> list[PosCodon]:
+    """Convert positional nucleotides to codons with quality scores."""
+
     meanq_int: int
     fragment_name: Header
     aapos: AAPos
-    codon_posnas: List[List[PosNA]]
+    codon_posnas: list[list[PosNA]]
     codon: CodonText
     is_partial: bool
     totalq: int
     sizeq: int
 
-    fragments: List[FragmentInterval] = find_intersected_fragments(
+    fragments: list[FragmentInterval] = find_intersected_fragments(
         fragment_intervals, read_refstart, read_refend)
-    basepairs: List[
-        Tuple[Header, List[BasePair]]
+    basepairs: list[
+        tuple[Header, list[BasePair]]
     ] = group_basepairs(posnas, fragments)
 
-    poscodons: List[PosCodon] = []
+    poscodons: list[PosCodon] = []
     for fragment_name, aapos, codon_posnas in group_codons(basepairs):
         codon, is_partial = get_comparable_codon(codon_posnas)
         if is_partial:
@@ -191,14 +192,14 @@ def iter_poscodons(
     samfile: str,
     samfile_start: int,
     samfile_end: int,
-    fragment_intervals: List[FragmentInterval],
+    fragment_intervals: list[FragmentInterval],
     site_quality_cutoff: int = 0
-) -> Generator[Tuple[Optional[Header], List[PosCodon]], None, None]:
+) -> Generator[tuple[Header | None, list[PosCodon]], None, None]:
     """Retrieve poscodons from given SAM/BAM file position range"""
 
     read: AlignedSegment
-    posnas: List[PosNA]
-    poscodons: List[PosCodon]
+    posnas: list[PosNA]
+    poscodons: list[PosCodon]
 
     with pysam.AlignmentFile(samfile, 'rb') as samfp:
         samfp.seek(samfile_start)

--- a/codfreq/posnas.py
+++ b/codfreq/posnas.py
@@ -3,7 +3,8 @@ import cython  # type: ignore
 from tqdm import tqdm  # type: ignore
 from array import array
 from pysam import AlignedSegment  # type: ignore
-from typing import List, Tuple, Optional, Generator, Any, Union
+from typing import Any
+from collections.abc import Generator
 from concurrent.futures import ProcessPoolExecutor
 
 from .json_progress import JsonProgress
@@ -13,7 +14,7 @@ from .codfreq_types import NAPos, NAChar, SeqText, Header
 ENCODING: str = 'UTF-8'
 GAP: int = ord(b'-')
 
-PosNA = Tuple[
+PosNA = tuple[
     NAPos,   # refpos
     int,     # insertion_index
     NAChar,  # na
@@ -26,11 +27,13 @@ PosNA = Tuple[
 @cython.returns(list)
 def iter_single_read_posnas(
     seq: SeqText,
-    qua: Optional[array],
-    aligned_pairs: List[Tuple[Optional[NAPos], Optional[NAPos]]]
-) -> List[PosNA]:
-    seqpos0: Optional[NAPos]
-    refpos0: Optional[NAPos]
+    qua: array | None,
+    aligned_pairs: list[tuple[NAPos | None, NAPos | None]]
+) -> list[PosNA]:
+    """Yield positional nucleotides with optional quality scores."""
+
+    seqpos0: NAPos | None
+    refpos0: NAPos | None
     refpos: NAPos
     insidx: int = 0
     n: NAChar
@@ -43,7 +46,7 @@ def iter_single_read_posnas(
 
     buffer_size: int = 0
 
-    posnas: List[PosNA] = []
+    posnas: list[PosNA] = []
 
     for seqpos0, refpos0 in aligned_pairs:
 
@@ -84,16 +87,13 @@ def get_posnas_between(
     samfile_start: int,
     samfile_end: int,
     site_quality_cutoff: int = 0
-) -> List[Tuple[Optional[Header], List[PosNA]]]:
+) -> list[tuple[Header | None, list[PosNA]]]:
+    """Extract positional nucleotides from a SAM file region."""
 
-    pos: NAPos
-    idx: int
-    na: NAChar
-    q: int
     read: AlignedSegment
-    posnas: List[PosNA]
+    posnas: list[PosNA]
 
-    results: List[Tuple[Optional[Header], List[PosNA]]] = []
+    results: list[tuple[Header | None, list[PosNA]]] = []
 
     with pysam.AlignmentFile(samfile, 'rb') as samfp:
 
@@ -130,16 +130,13 @@ def get_posnas_in_genome_region(
     ref_start: NAPos,
     ref_end: NAPos,
     site_quality_cutoff: int = 0
-) -> List[Tuple[Optional[Header], List[PosNA]]]:
+) -> list[tuple[Header | None, list[PosNA]]]:
+    """Retrieve positional nucleotides for a genomic range."""
 
-    pos: NAPos
-    idx: int
-    na: NAChar
-    q: int
     read: AlignedSegment
-    posnas: List[PosNA]
+    posnas: list[PosNA]
 
-    results: List[Tuple[Optional[Header], List[PosNA]]] = []
+    results: list[tuple[Header | None, list[PosNA]]] = []
 
     with pysam.AlignmentFile(samfile, 'rb') as samfp:
 
@@ -174,18 +171,14 @@ def iter_posnas(
     log_format: str = 'text',
     **extras: Any
 ) -> Generator[
-    Tuple[Header, List[PosNA]],
+    tuple[Header, list[PosNA]],
     None,
     None
 ]:
+    """Iterate positional nucleotides across a SAM file with progress."""
+
     total: int
-    header: Header
-    chunks: List[Tuple[int, int]]
-    samfile_begin: int
-    samfile_end: int
-    one: Tuple[Header, List[PosNA]]
-    posnas: List[Tuple[Header, List[PosNA]]]
-    pbar: Optional[Union[JsonProgress, tqdm]] = None
+    pbar: JsonProgress | tqdm | None = None
 
     with pysam.AlignmentFile(samfile, 'rb') as samfp:
         total = samfp.mapped
@@ -197,7 +190,7 @@ def iter_posnas(
                 **extras)
         elif log_format == 'text':
             pbar = tqdm(total=total)
-            pbar.set_description('Processing {}'.format(description))
+            pbar.set_description(f'Processing {description}')
 
     chunks = chunked_samfile(samfile, chunk_size)
 

--- a/codfreq/posnas_types.py
+++ b/codfreq/posnas_types.py
@@ -1,8 +1,7 @@
-from typing import Tuple
 from .codfreq_types import NAPos, NAChar
 
 
-PosNA = Tuple[
+PosNA = tuple[
     NAPos,   # refpos
     int,     # insertion_index
     NAChar,  # na

--- a/codfreq/sam2codfreq.py
+++ b/codfreq/sam2codfreq.py
@@ -5,14 +5,8 @@ from collections import Counter
 from more_itertools import unique_everseen
 
 from typing import (
-    Tuple,
-    List,
-    Dict,
-    Optional,
     Any,
-    Union,
-    Literal,
-    Counter as tCounter
+    Literal
 )
 from concurrent.futures import ProcessPoolExecutor
 
@@ -44,7 +38,7 @@ from .codonalign_consensus import codonalign_consensus
 from .filename_helper import name_bamfile
 
 
-CODFREQ_HEADER: List[str] = [
+CODFREQ_HEADER: list[str] = [
     'gene', 'position',
     'total', 'codon', 'count',
     'total_quality_score'
@@ -57,8 +51,10 @@ ENCODING: str = 'UTF-8'
 @cython.inline
 @cython.returns(list)
 def build_fragment_intervals(
-    fragments: List[DerivedFragmentConfig]
-) -> List[FragmentInterval]:
+    fragments: list[DerivedFragmentConfig]
+) -> list[FragmentInterval]:
+    """Extract fragment reference intervals for codon processing."""
+
     return [(
         fragment['refRanges'],
         fragment['fragmentName']
@@ -68,11 +64,11 @@ def build_fragment_intervals(
 @cython.cfunc
 @cython.inline
 @cython.returns(list)
-def get_ref_ranges(config: Dict) -> List[NAPosRange]:
+def get_ref_ranges(config: dict) -> list[NAPosRange]:
     refstart = config.get('refStart')
     refend = config.get('refEnd')
     orig_refranges = config.get('refRanges')
-    refranges: List[NAPosRange] = []
+    refranges: list[NAPosRange] = []
     if isinstance(orig_refranges, list):
         refranges = [(start, end) for start, end in orig_refranges]
     elif isinstance(refstart, int) and isinstance(refend, int):
@@ -85,23 +81,23 @@ def get_ref_ranges(config: Dict) -> List[NAPosRange]:
 @cython.returns(tuple)
 def get_ref_fragments(
     profile: Profile
-) -> Tuple[
-    List[Tuple[
+) -> tuple[
+    list[tuple[
         Header,
         MainFragmentConfig,
-        List[DerivedFragmentConfig]
+        list[DerivedFragmentConfig]
     ]],
     FragmentGeneLookup
 ]:
     refname: str
-    codon_alignment: Optional[Union[
-        Literal[False],
-        List[CodonAlignmentConfig]
-    ]]
+    codon_alignment: None | (
+        Literal[False] |
+        list[CodonAlignmentConfig]
+    )
     cda: CodonAlignmentConfig
     config: FragmentConfig
-    ref_fragments: Dict[Header, TypedRefFragment] = {}
-    frag_size_lookup: Dict[Header, AAPos] = {}
+    ref_fragments: dict[Header, TypedRefFragment] = {}
+    frag_size_lookup: dict[Header, AAPos] = {}
     for config in profile['fragmentConfig']:
         refname = config['fragmentName']
         refseq = config.get('refSequence')
@@ -155,7 +151,7 @@ def get_ref_fragments(
             ) // 3
 
     # build frag_gene_lookup
-    gene_offsets: Dict[GeneText, AAPos] = {}
+    gene_offsets: dict[GeneText, AAPos] = {}
     frag_gene_lookup: FragmentGeneLookup = {}
     for config in profile['fragmentConfig']:
         refname = config['fragmentName']
@@ -185,12 +181,13 @@ def get_ref_fragments(
 def to_codon_counter_by_fragpos(
     codon_counter: CodonCounter
 ) -> CodonCounterByFragPos:
+    """Reindex codon counts keyed by fragment and position."""
+
     fragment_name: Header
     refpos: AAPos
-    codons: tCounter[CodonText]
     codon: CodonText
-    reformed: Dict[
-        Tuple[Header, AAPos],
+    reformed: dict[
+        tuple[Header, AAPos],
         Counter[CodonText]
     ] = {}
 
@@ -210,18 +207,19 @@ def get_codonfreq(
     codonstat_by_fragpos: CodonCounterByFragPos,
     qualities_by_fragpos: CodonCounterByFragPos,
     frag_gene_lookup: FragmentGeneLookup
-) -> List[CodFreqRow]:
+) -> list[CodFreqRow]:
+    """Calculate codon frequencies with quality scores."""
+
     fragment_name: Header
     gene: GeneText
     gene_offset: AAPos
     refpos: AAPos
-    codons: tCounter[CodonText]
     codon: CodonText
     count: int
     qua: int
     total: int
-    rows: List[CodFreqRow] = []
-    ordered_genes: List[GeneText] = list(unique_everseen([
+    rows: list[CodFreqRow] = []
+    ordered_genes: list[GeneText] = list(unique_everseen([
         gene for genes in frag_gene_lookup.values() for gene, _ in genes
     ]))
 
@@ -252,9 +250,9 @@ def sam2codfreq_between(
     samfile: str,
     samfile_start: int,
     samfile_end: int,
-    fragment_intervals: List[FragmentInterval],
+    fragment_intervals: list[FragmentInterval],
     site_quality_cutoff: int = 0
-) -> Tuple[CodonCounter, CodonCounter, int]:
+) -> tuple[CodonCounter, CodonCounter, int]:
     """subprocess function to call iter_poscodons and count codons
 
     The results of PosCodons are aggregated into codon counters to reduce
@@ -272,7 +270,7 @@ def sam2codfreq_between(
     The solution is simple, just processing the partial results in subprocess
     instead of in main process.
     """
-    poscodons: List[PosCodon]
+    poscodons: list[PosCodon]
     fragment_name: str
     refpos: int
     codon: CodonText
@@ -299,14 +297,14 @@ def sam2codfreq_between(
 def sam2codfreq(
     samfile: str,
     ref: MainFragmentConfig,
-    fragments: List[DerivedFragmentConfig],
+    fragments: list[DerivedFragmentConfig],
     workers: int,
     site_quality_cutoff: int = 0,
     log_format: str = 'text',
     include_partial_codons: bool = False,
     chunk_size: int = 25000,
     **extras: Any
-) -> Tuple[CodonCounterByFragPos, CodonCounterByFragPos]:
+) -> tuple[CodonCounterByFragPos, CodonCounterByFragPos]:
     """Returns CodFreq rows from a SAM/BAM file
 
     This function utilizes subprocesses to process alignment data from a
@@ -330,7 +328,7 @@ def sam2codfreq(
     """
 
     total: int
-    pbar: Optional[Union[JsonProgress, tqdm]]
+    pbar: JsonProgress | tqdm | None
 
     with pysam.AlignmentFile(samfile, 'rb') as samfp:
         total = samfp.mapped
@@ -339,10 +337,10 @@ def sam2codfreq(
                 total=total, description=samfile, **extras)
         elif log_format == 'text':
             pbar = tqdm(total=total)
-            pbar.set_description('Processing {}'.format(samfile))
+            pbar.set_description(f'Processing {samfile}')
 
-    chunks: List[Tuple[int, int]] = chunked_samfile(samfile, chunk_size)
-    fragment_intervals: List[
+    chunks: list[tuple[int, int]] = chunked_samfile(samfile, chunk_size)
+    fragment_intervals: list[
         FragmentInterval
     ] = build_fragment_intervals(fragments)
     codonstat: CodonCounter = Counter()
@@ -395,16 +393,16 @@ def sam2codfreq(
 
 def sam2codfreq_all(
     name: str,
-    fnpair: Tuple[Optional[FASTQFileName], ...],
+    fnpair: tuple[FASTQFileName | None, ...],
     profile: Profile,
     workers: int,
     site_quality_cutoff: int = 0,
     log_format: str = 'text',
     include_partial_codons: bool = False
-) -> List[CodFreqRow]:
+) -> list[CodFreqRow]:
     refname: str
     ref: MainFragmentConfig
-    fragments: List[DerivedFragmentConfig]
+    fragments: list[DerivedFragmentConfig]
     ref_fragments, frag_gene_lookup = get_ref_fragments(profile)
     all_codonstat_by_fragpos: CodonCounterByFragPos = {}
     all_qualities_by_fragpos: CodonCounterByFragPos = {}
@@ -423,7 +421,7 @@ def sam2codfreq_all(
         all_codonstat_by_fragpos.update(codonstat_by_fragpos)
         all_qualities_by_fragpos.update(qualities_by_fragpos)
 
-    codfreq_rows: List[CodFreqRow] = get_codonfreq(
+    codfreq_rows: list[CodFreqRow] = get_codonfreq(
         all_codonstat_by_fragpos,
         all_qualities_by_fragpos,
         frag_gene_lookup

--- a/codfreq/sam2codfreq_types.py
+++ b/codfreq/sam2codfreq_types.py
@@ -1,10 +1,7 @@
 from typing import (
-    Dict,
-    Tuple,
-    List,
-    TypedDict,
-    Counter
+    TypedDict
 )
+from collections import Counter
 from .codfreq_types import (
     Header,
     AAPos,
@@ -17,21 +14,21 @@ from .codfreq_types import (
 
 class TypedRefFragment(TypedDict):
     ref: MainFragmentConfig
-    fragments: List[DerivedFragmentConfig]
+    fragments: list[DerivedFragmentConfig]
 
 
 CodonCounter = Counter[
-    Tuple[Header, AAPos, CodonText]
+    tuple[Header, AAPos, CodonText]
 ]
 
-CodonCounterByFragPos = Dict[
-    Tuple[Header, AAPos],
+CodonCounterByFragPos = dict[
+    tuple[Header, AAPos],
     Counter[CodonText]
 ]
 
-FragmentGeneLookup = Dict[
-    Header, List[
-        Tuple[GeneText, AAPos]
+FragmentGeneLookup = dict[
+    Header, list[
+        tuple[GeneText, AAPos]
         #                 ^
         #              AAOffset
     ]

--- a/codfreq/sam2consensus.py
+++ b/codfreq/sam2consensus.py
@@ -1,14 +1,7 @@
 import json
 import cython  # type: ignore
 from collections import defaultdict, Counter
-
-from typing import (
-    DefaultDict,
-    Counter as tCounter,
-    Tuple,
-    List,
-    Dict
-)
+from collections import Counter as tCounter
 from .codfreq_types import (
     NAPos,
     NAChar,
@@ -18,7 +11,7 @@ from .codfreq_types import (
     NARegionConfig,
     RegionalConsensus
 )
-from .posnas import get_posnas_in_genome_region, PosNA
+from .posnas import get_posnas_in_genome_region
 
 from .filename_helper import name_bamfile
 
@@ -31,9 +24,11 @@ ENCODING = 'UTF-8'
 @cython.inline
 @cython.returns(dict)
 def make_consensus(
-    nacons_lookup: Dict[Tuple[NAPos, int], NAChar],
+    nacons_lookup: dict[tuple[NAPos, int], NAChar],
     region: NARegionConfig
 ) -> RegionalConsensus:
+    """Build consensus sequence for a region from nucleotide counts."""
+
     refpos: NAPos
     idx: int
 
@@ -65,18 +60,10 @@ def sam2consensus(
     sampath: str,
     region: NARegionConfig,
 ) -> RegionalConsensus:
+    """Generate consensus sequence for a region from a SAM file."""
 
-    name: str
-    refpos_start: NAPos
-    refpos_end: NAPos
-    consarr: bytearray
-    posnas: List[PosNA]
-    refpos: NAPos
-    idx: int
-    na: NAChar
-
-    nafreqs: DefaultDict[
-        Tuple[NAPos, int],
+    nafreqs: defaultdict[
+        tuple[NAPos, int],
         tCounter[NAChar]
     ] = defaultdict(Counter)
 
@@ -89,11 +76,11 @@ def sam2consensus(
         for refpos, idx, na, _ in posnas:
             nafreqs[(refpos, idx)][na] += 1
 
-    nacons_with_count_lookup: Dict[Tuple[NAPos, int], Tuple[NAChar, int]] = {
+    nacons_with_count_lookup: dict[tuple[NAPos, int], tuple[NAChar, int]] = {
         pos: nas.most_common(1)[0]
         for pos, nas in nafreqs.items()
     }
-    nacons_lookup: Dict[Tuple[NAPos, int], NAChar] = {
+    nacons_lookup: dict[tuple[NAPos, int], NAChar] = {
         (pos, idx): na
         for (pos, idx), (na, count) in nacons_with_count_lookup.items()
         if idx == 0 or
@@ -118,7 +105,7 @@ def create_untrans_region_consensus(
     fragment: FragmentConfig
     region: SequenceAssemblyConfig
 
-    results: List[RegionalConsensus] = []
+    results: list[RegionalConsensus] = []
     for fragment in profile['fragmentConfig']:
         if 'fromFragment' in fragment:
             continue
@@ -145,5 +132,5 @@ def create_untrans_region_consensus(
                     'refEnd': region['refEnd']
                 }
             ))
-    with open('{}.untrans.json'.format(seqname), 'w') as fp:
+    with open(f'{seqname}.untrans.json', 'w') as fp:
         json.dump(results, fp)

--- a/codfreq/sam2consensus.py
+++ b/codfreq/sam2consensus.py
@@ -1,7 +1,6 @@
 import json
 import cython  # type: ignore
 from collections import defaultdict, Counter
-from collections import Counter as tCounter
 from .codfreq_types import (
     NAPos,
     NAChar,
@@ -64,7 +63,7 @@ def sam2consensus(
 
     nafreqs: defaultdict[
         tuple[NAPos, int],
-        tCounter[NAChar]
+        Counter[NAChar]
     ] = defaultdict(Counter)
 
     for _, posnas in get_posnas_in_genome_region(

--- a/codfreq/sam_prep.py
+++ b/codfreq/sam_prep.py
@@ -1,4 +1,3 @@
-from collections import Counter as tCounter
 from collections import Counter
 
 from pysam import AlignmentFile
@@ -57,7 +56,7 @@ def squash_gaps(
 def count_indel_positions(
     cigartuples: tuple[tuple[int, int], ...],
     ref_start: int,
-    indel_counter: tCounter[int]
+    indel_counter: Counter[int]
 ) -> None:
     """Count indel positions in cigar tuples.
 
@@ -76,7 +75,7 @@ def count_indel_positions(
 def prepare_sam(sam_file: str, out_file: str) -> None:
     """Prepare SAM/BAM alignment files for downstream analysis."""
     cigars: list[tuple[tuple[int, int], ...]] = []
-    indel_counter: tCounter[int] = Counter()
+    indel_counter: Counter[int] = Counter()
 
     with AlignmentFile(sam_file, "r") as sam, \
             AlignmentFile(out_file, "w", template=sam) as out:

--- a/codfreq/sam_prep.py
+++ b/codfreq/sam_prep.py
@@ -1,13 +1,13 @@
-from typing import Tuple, List, Counter as tCounter, Optional
+from collections import Counter as tCounter
 from collections import Counter
 
 from pysam import AlignmentFile
 
 
 def squash_gaps(
-    cigartuples: Tuple[Tuple[int, int], ...],
+    cigartuples: tuple[tuple[int, int], ...],
     max_squashing_distance: int = 10
-) -> Tuple[Tuple[int, int], ...]:
+) -> tuple[tuple[int, int], ...]:
     """Squash gaps in cigar tuples.
 
     This function squashs neighboring deletions and insertions (the distance of
@@ -16,7 +16,7 @@ def squash_gaps(
     """
     # Squash neighboring deletions and insertions
     tmp_cigartuples = list(cigartuples)
-    prev_indel_idx: Optional[int] = None
+    prev_indel_idx: int | None = None
     prev_indel_dist: int = 0
     for idx, (op, length) in enumerate(tmp_cigartuples):
         if op in (1, 2):
@@ -43,7 +43,7 @@ def squash_gaps(
             prev_indel_dist += length
 
     # Remove zero-length operations and merge adjacent operations
-    result_cigartuples: List[Tuple[int, int]] = []
+    result_cigartuples: list[tuple[int, int]] = []
     for op, length in tmp_cigartuples:
         if length == 0:
             continue
@@ -55,7 +55,7 @@ def squash_gaps(
 
 
 def count_indel_positions(
-    cigartuples: Tuple[Tuple[int, int], ...],
+    cigartuples: tuple[tuple[int, int], ...],
     ref_start: int,
     indel_counter: tCounter[int]
 ) -> None:
@@ -75,7 +75,7 @@ def count_indel_positions(
 
 def prepare_sam(sam_file: str, out_file: str) -> None:
     """Prepare SAM/BAM alignment files for downstream analysis."""
-    cigars: List[Tuple[Tuple[int, int], ...]] = []
+    cigars: list[tuple[tuple[int, int], ...]] = []
     indel_counter: tCounter[int] = Counter()
 
     with AlignmentFile(sam_file, "r") as sam, \
@@ -85,12 +85,12 @@ def prepare_sam(sam_file: str, out_file: str) -> None:
             if read.is_unmapped:
                 cigars.append(())
                 continue
-            cigars.append(squash_gaps(read.cigartuples))
+            cigars.append(squash_gaps(tuple(read.cigartuples or ())))
             count_indel_positions(
                 cigars[-1], read.reference_start, indel_counter)
 
         sam.seek(fp)
         for read, cigar in zip(sam, cigars):
             # TODO: modify cigar according to indel_counter
-            read.cigartuples = cigar
+            read.cigartuples = list(cigar)
             out.write(read)

--- a/codfreq/samfile_helper.py
+++ b/codfreq/samfile_helper.py
@@ -1,6 +1,5 @@
 import pysam  # type: ignore
 import cython  # type: ignore
-from typing import List, Tuple
 
 
 @cython.ccall
@@ -9,10 +8,10 @@ from typing import List, Tuple
 def chunked_samfile(
     samfile: str,
     chunk_size: int = 50000
-) -> List[Tuple[int, int]]:
+) -> list[tuple[int, int]]:
     """Find out positions in sam/bam file for given chunk_size"""
 
-    chunks: List[Tuple[int, int]] = []
+    chunks: list[tuple[int, int]] = []
     cur_chunk_size: int
     cur_begin: int
     cur_end: int

--- a/lambda-controller/main.py
+++ b/lambda-controller/main.py
@@ -70,7 +70,7 @@ def save_taskmeta(uniqkey, status, payload=None):
     now = utcnow_text()
     S3.put_object(
         Bucket=S3_BUCKET,
-        Key='tasks/{}/taskmeta.json'.format(uniqkey),
+        Key=f'tasks/{uniqkey}/taskmeta.json',
         ContentType='application/json',
         Body=json.dumps({
             'taskKey': uniqkey,
@@ -85,7 +85,7 @@ def save_taskmeta(uniqkey, status, payload=None):
 def save_file(uniqkey, config_file, content_type, payload):
     S3.put_object(
         Bucket=S3_BUCKET,
-        Key='tasks/{}/{}'.format(uniqkey, config_file),
+        Key=f'tasks/{uniqkey}/{config_file}',
         ContentType=content_type,
         Body=payload.encode('U8')
     )
@@ -101,30 +101,30 @@ def save_pairinfo(uniqkey, pairinfo):
 
 
 def verify_pairinfo(pairinfo, fastq_files):
-    known_names = set([])
+    known_names = set()
     for idx, one in enumerate(pairinfo):
         if 'name' not in one:
-            return False, "item {} misses property 'name'".format(idx)
+            return False, f"item {idx} misses property 'name'"
         if 'pair' not in one:
-            return False, "item {} misses property 'pair'".format(idx)
+            return False, f"item {idx} misses property 'pair'"
         if 'n' not in one:
-            return False, "item {} misses property 'n'".format(idx)
+            return False, f"item {idx} misses property 'n'"
         if one['name'] in known_names:
-            return False, "item {} has duplicate name".format(idx)
+            return False, f"item {idx} has duplicate name"
         if len(one['pair']) > 2:
             return (
                 False,
-                "item {}'s property 'pair' has too many files".format(idx)
+                f"item {idx}'s property 'pair' has too many files"
             )
         if len(one['pair']) < 2:
             return (
                 False,
-                "item {}'s property 'pair' has too few file".format(idx)
+                f"item {idx}'s property 'pair' has too few file"
             )
         if one['n'] == 2 and any(f is None for f in one['pair']):
             return (
                 False,
-                "item {}'s property 'pair' doesn't match n=2".format(idx)
+                f"item {idx}'s property 'pair' doesn't match n=2"
             )
         if (
             one['n'] == 1 and
@@ -133,7 +133,7 @@ def verify_pairinfo(pairinfo, fastq_files):
         ):
             return (
                 False,
-                "item {}'s property 'pair' doesn't match n=1".format(idx)
+                f"item {idx}'s property 'pair' doesn't match n=1"
             )
         files = {f for f in one['pair'] if f is not None}
         missing_files = files - fastq_files
@@ -150,7 +150,7 @@ def verify_pairinfo(pairinfo, fastq_files):
 def load_taskmeta(uniqkey):
     obj = S3.get_object(
         Bucket=S3_BUCKET,
-        Key='tasks/{}/taskmeta.json'.format(uniqkey)
+        Key=f'tasks/{uniqkey}/taskmeta.json'
     )
     data = json.load(obj['Body'])
     data['lastUpdatedAt'] = parse_dt(data['lastUpdatedAt'])
@@ -162,7 +162,7 @@ def verify_profiles(profiles):
         try:
             S3.head_object(
                 Bucket=S3_BUCKET,
-                Key='profiles/{}'.format(profile)
+                Key=f'profiles/{profile}'
             )
         except S3.exceptions.NoSuchKey:
             return False
@@ -314,7 +314,7 @@ def fetch_codfreqs(request):
         'get_object',
         Params={
             'Bucket': S3_BUCKET,
-            'Key': 'tasks/{}/response.json'.format(uniqkey)
+            'Key': f'tasks/{uniqkey}/response.json'
         },
         ExpiresIn=300)
 
@@ -338,7 +338,7 @@ def fetch_allfiles(request):
     if not is_success(taskmeta):
         return {"error": "this task is not finished yet"}, 400
 
-    path_prefix = 'tasks/{}/'.format(uniqkey)
+    path_prefix = f'tasks/{uniqkey}/'
     lskw = {
         'Bucket': S3_BUCKET,
         'MaxKeys': 1000,
@@ -385,7 +385,7 @@ def fetch_codfreqs_zip(request):
         'get_object',
         Params={
             'Bucket': S3_BUCKET,
-            'Key': 'tasks/{}/codfreqs.zip'.format(uniqkey)
+            'Key': f'tasks/{uniqkey}/codfreqs.zip'
         },
         ExpiresIn=300)
 
@@ -429,8 +429,8 @@ def fetch_runner_logs(request):
     for task_id, stime in zip(ecs_task_ids, start_time):
         events = []
         kw = dict(
-            logGroupName='/ecs/{}'.format(ECS_TASK_DEFINITION),
-            logStreamName='ecs/{}'.format(task_id),
+            logGroupName=f'/ecs/{ECS_TASK_DEFINITION}',
+            logStreamName=f'ecs/{task_id}',
             startTime=stime, limit=limit)
         done = False
         while True:
@@ -496,7 +496,7 @@ def trigger_runner(request):
         return {"error": "this task is not ready for a runner"}, 400
     payload = taskmeta['payload']
     fastq_files = set(payload['fastqFiles'])
-    path_prefix = 'tasks/{}/'.format(uniqkey)
+    path_prefix = f'tasks/{uniqkey}/'
     result = S3.list_objects_v2(
         Bucket=S3_BUCKET,
         MaxKeys=len(fastq_files) + 6,
@@ -613,7 +613,7 @@ def direct_upload(request):
         sigs.append(
             S3.generate_presigned_post(
                 Bucket=S3_BUCKET,
-                Key='tasks/{}/{}'.format(uniqkey, filename),
+                Key=f'tasks/{uniqkey}/{filename}',
                 Fields={'content-type': 'binary/octet-stream'},
                 Conditions=[{'content-type': 'binary/octet-stream'}],
                 ExpiresIn=3600

--- a/scripts/codfreq2aafreq.py
+++ b/scripts/codfreq2aafreq.py
@@ -6,12 +6,10 @@ import gzip
 import argparse
 from collections import Counter, defaultdict
 
-from typing import (
-    Dict, TextIO, Tuple, Counter as tCounter,
-    Optional, List, DefaultDict
-)
+from typing import TextIO
+from collections import Counter as tCounter
 
-CODON_TABLE: Dict[str, str] = {
+CODON_TABLE: dict[str, str] = {
     'TTT': 'F',
     'TTC': 'F',
     'TTA': 'L',
@@ -95,7 +93,9 @@ CODON_TABLE: Dict[str, str] = {
 }
 
 
-def codon_to_aa(codon: str) -> Tuple[str, str]:
+def codon_to_aa(codon: str) -> tuple[str, str]:
+    """Translate a codon into an amino acid and insertions."""
+
     nogap = codon.replace('-', '')
     nogap_len = len(nogap)
     if codon in ('', '---'):
@@ -114,6 +114,8 @@ def codon_to_aa(codon: str) -> Tuple[str, str]:
 
 
 def directory(path: str) -> str:
+    """Validate that a command-line argument is an existing directory."""
+
     if os.path.isdir(path):
         return path
     else:
@@ -121,6 +123,8 @@ def directory(path: str) -> str:
 
 
 def main() -> None:
+    """CLI entry point for converting CodFreq files to AA frequencies."""
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         'codfreq_dir',
@@ -135,8 +139,8 @@ def main() -> None:
     args = parser.parse_args()
     os.makedirs(args.aafreq_dir, exist_ok=True)
     for filename in os.listdir(args.codfreq_dir):
-        fpin: Optional[TextIO] = None
-        fpout: Optional[TextIO] = None
+        fpin: TextIO | None = None
+        fpout: TextIO | None = None
         name: str
         lower = filename.lower()
         filepath = os.path.join(args.codfreq_dir, filename)
@@ -151,19 +155,18 @@ def main() -> None:
                 name = filename[:-8]
                 fpin = open(
                     filepath,
-                    'r',
                     encoding='utf-8-sig')
             if fpin is None:
                 continue
-            aacounter: DefaultDict[
-                Tuple[str, str],
-                tCounter[Tuple[str, str]]
+            aacounter: defaultdict[
+                tuple[str, str],
+                tCounter[tuple[str, str]]
             ] = defaultdict(Counter)
-            codons: DefaultDict[
-                Tuple[str, str, str, str],
-                List[str]
+            codons: defaultdict[
+                tuple[str, str, str, str],
+                list[str]
             ] = defaultdict(list)
-            totals: Dict[Tuple[str, str], int] = {}
+            totals: dict[tuple[str, str], int] = {}
             for row in csv.reader(fpin):
                 if not row:
                     continue

--- a/scripts/codfreq2fasta.py
+++ b/scripts/codfreq2fasta.py
@@ -1,7 +1,5 @@
 #! /usr/bin/env python
 
-from __future__ import print_function
-from __future__ import division
 import re
 import sys
 import csv
@@ -45,7 +43,7 @@ def main():
     with open(sys.argv[2], 'w') as out:
         for fname in sys.argv[3:]:
             cons = []
-            with open(fname, 'r') as fp:
+            with open(fname) as fp:
                 all_codons = defaultdict(set)
                 reader = csv.reader(fp, delimiter='\t')
                 for gene, cdpos, total, codon, read, *_ in reader:
@@ -81,7 +79,7 @@ def main():
                         cons.append(nas)
             cons = ''.join(cons).strip('N')
             header = fname.rsplit('/', 1)[-1].rsplit('.', 1)[0]
-            out.write('>{}\n{}\n'.format(header, cons))
+            out.write(f'>{header}\n{cons}\n')
 
 
 if __name__ == '__main__':

--- a/scripts/codonutils.py
+++ b/scripts/codonutils.py
@@ -129,7 +129,7 @@ def translate_codons(nas, ambiguous_x=True):
             if ambiguous_x:
                 aas = 'X'
             else:
-                aas = '[{}]'.format(aas)
+                aas = f'[{aas}]'
         all_aas.append(aas)
     return ''.join(all_aas)
 

--- a/scripts/nucfreq2fasta.py
+++ b/scripts/nucfreq2fasta.py
@@ -1,7 +1,5 @@
 #! /usr/bin/env python
 
-from __future__ import print_function
-from __future__ import division
 import os
 import re
 import sys
@@ -44,7 +42,7 @@ def main():
                 continue
             fname = os.path.join(inputdir, fname)
             cons = []
-            with open(fname, 'r') as fp:
+            with open(fname) as fp:
                 all_nas = defaultdict(set)
                 reader = csv.reader(fp, delimiter='\t')
                 for napos, total, na, read, insdetail, *_ in reader:
@@ -93,7 +91,7 @@ def main():
                         cons.append(single_nas)
             cons = ''.join(cons).strip('N')
             header = fname.rsplit('/', 1)[-1].rsplit('.', 1)[0]
-            out.write('>{}\n{}\n'.format(header, cons))
+            out.write(f'>{header}\n{cons}\n')
 
 
 if __name__ == '__main__':

--- a/scripts/sam2codfreq.py
+++ b/scripts/sam2codfreq.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
 
-from __future__ import print_function
 import os
 import sys
 import csv
@@ -115,7 +114,7 @@ def reads_producer(filename, offset):
 
 def main():
     if len(sys.argv) != 3:
-        print("Usage: {} <SAMFILE> <OUTPUT>".format(sys.argv[0]),
+        print(f"Usage: {sys.argv[0]} <SAMFILE> <OUTPUT>",
               file=sys.stderr)
         exit(1)
     with pysam.AlignmentFile(sys.argv[1], 'rb') as samfile:
@@ -161,10 +160,10 @@ def main():
             for codon, read in sorted(counter.items(),
                                       key=lambda it: (-it[1], it[0])):
                 writer.writerow([gene, cdpos, total, codon, read])
-    print('{} reads processed. Of them:'.format(num_finished))
-    print('  Length of {} were too short'.format(num_tooshort))
-    print('  Quality of {} were too low'.format(num_lowqual))
-    print("{} done.".format(sys.argv[2]))
+    print(f'{num_finished} reads processed. Of them:')
+    print(f'  Length of {num_tooshort} were too short')
+    print(f'  Quality of {num_lowqual} were too low')
+    print(f"{sys.argv[2]} done.")
 
 
 if __name__ == '__main__':

--- a/scripts/sam2nucfreq.py
+++ b/scripts/sam2nucfreq.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
 
-from __future__ import print_function
 import os
 import sys
 import csv
@@ -127,7 +126,7 @@ def reads_producer(filename, offset):
 
 def main():
     if len(sys.argv) != 3:
-        print("Usage: {} <SAMFILE> <OUTPUT>".format(sys.argv[0]),
+        print(f"Usage: {sys.argv[0]} <SAMFILE> <OUTPUT>",
               file=sys.stderr)
         exit(1)
     samfile_path = sys.argv[1]
@@ -137,7 +136,7 @@ def main():
     reffilepath = samfile_path[:-4] + '.lastref.fas'
     profile = []
     if os.path.isfile(reffilepath):
-        with open(reffilepath, 'r') as reffile:
+        with open(reffilepath) as reffile:
             profile_tmp = [
                 s['sequence']
                 for s in fastareader.load(reffile)
@@ -196,7 +195,7 @@ def main():
                 ins = ''
                 if na == 'i':
                     ins = ', '.join(
-                        '{} ({})'.format(insna, insread)
+                        f'{insna} ({insread})'
                         for insna, insread in
                         insdetail[refpos].most_common()
                     )
@@ -214,13 +213,13 @@ def main():
                     refpos, total,
                     na.replace('i', 'ins').replace('d', 'del'),
                     read, ins,
-                    '{}%'.format(read / total * 100),
+                    f'{read / total * 100}%',
                     *poprows
                 ])
-    print('{} reads processed. Of them:'.format(num_finished))
-    print('  Length of {} were too short'.format(num_tooshort))
-    print('  Quality of {} were too low'.format(num_lowqual))
-    print("{} done.".format(sys.argv[2]))
+    print(f'{num_finished} reads processed. Of them:')
+    print(f'  Length of {num_tooshort} were too short')
+    print(f'  Quality of {num_lowqual} were too low')
+    print(f"{sys.argv[2]} done.")
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-# -*- coding: UTF-8 -*-
 
 import os
 # import re
@@ -64,17 +63,17 @@ def pep508(line: str) -> str:
         return line
     if '://' in line and 'post-align' in line:
         url = line.split('#egg=', 1)
-        return 'post-align @ {}'.format(url[0].strip())
+        return f'post-align @ {url[0].strip()}'
     return line
 
 
 def req(filename: str) -> list[str]:
     with open(os.path.join(os.getcwd(), filename)) as fp:
-        requires = set(
+        requires = {
             strip_comments(pep508(ln))
             for ln in fp.readlines()
-        )
-        requires -= set([''])
+        }
+        requires -= {''}
     return list(requires)
 
 


### PR DESCRIPTION
## Summary
- replace legacy `typing` collections with built-in generics and unions
- use `collections.defaultdict` and `collections.abc` types where appropriate
- enrich helper functions with Sphinx-style docstrings and fix mypy typing issues

## Testing
- `pipenv run flake8 .`
- `pipenv run mypy codfreq`
- `pipenv run pytest --cov=codfreq --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_6898d07de6a8832491f445a7ce5f4b44