### PR TITLE
test: expand coverage for cmdwrappers posnas align

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@ This repo uses automation agents (local or CI) to keep code healthy and consiste
 - **Dependencies**: keep them up to date with minimal, safe upgrades.
 - **Changes**: when you touch code, you also add/update tests.
 - **Cleanup**: remove unused and unexposed code.
+- **External deps**: do not vendor or stub third-party packages in the repo;
+  tests should use ``unittest.mock`` (e.g. ``mock.patch``) to simulate them.
 
 
 ## Environment & packaging

--- a/tests/mock_postalign.py
+++ b/tests/mock_postalign.py
@@ -26,6 +26,19 @@ def mock_postalign() -> Iterator[None]:
     models = ModuleType("postalign.models")
     models.__path__ = []  # type: ignore[attr-defined]
 
+    cython = ModuleType("cython")
+
+    def _decorator(*dargs: Any, **dkwargs: Any) -> Any:  # pragma: no cover
+        if dargs and callable(dargs[0]):
+            return dargs[0]
+        return lambda func: func
+
+    cython.ccall = _decorator  # type: ignore[attr-defined]
+    cython.inline = _decorator  # type: ignore[attr-defined]
+    cython.returns = lambda *a, **k: _decorator  # type: ignore[attr-defined]
+    cython.void = None  # type: ignore[attr-defined]
+    cython.cfunc = _decorator  # type: ignore[attr-defined]
+
     def group_by_codons(
         seq1: bytearray, seq2: bytearray
     ) -> tuple[list[bytearray], list[bytearray]]:
@@ -103,6 +116,7 @@ def mock_postalign() -> Iterator[None]:
         "postalign.processors.codon_alignment": processors_codon,
         "postalign.models": models,
         "postalign.models.sequence": models_seq,
+        "cython": cython,
     }
 
     with patch.dict(sys.modules, modules):

--- a/tests/mock_postalign.py
+++ b/tests/mock_postalign.py
@@ -1,0 +1,109 @@
+"""Helpers for patching the optional PostAlign dependency."""
+
+from __future__ import annotations
+
+import sys
+from contextlib import contextmanager
+from types import ModuleType
+from typing import Any, Iterator
+from unittest.mock import patch
+
+
+@contextmanager
+def mock_postalign() -> Iterator[None]:
+    """Patch ``postalign`` modules with lightweight stand-ins.
+
+    These mocks provide just enough functionality for the parts of CodFreq
+    exercised in tests while avoiding a runtime dependency on the actual
+    PostAlign package.
+    """
+    postalign = ModuleType("postalign")
+    postalign.__path__ = []  # type: ignore[attr-defined]
+    utils = ModuleType("postalign.utils")
+    utils.__path__ = []  # type: ignore[attr-defined]
+    processors = ModuleType("postalign.processors")
+    processors.__path__ = []  # type: ignore[attr-defined]
+    models = ModuleType("postalign.models")
+    models.__path__ = []  # type: ignore[attr-defined]
+
+    def group_by_codons(
+        seq1: bytearray, seq2: bytearray
+    ) -> tuple[list[bytearray], list[bytearray]]:
+        """Split two sequences into codon-sized chunks."""
+
+        def chunk(seq: bytearray) -> list[bytearray]:
+            return [seq[i:i + 3] for i in range(0, len(seq), 3)]
+
+        return chunk(seq1), chunk(seq2)
+
+    utils_group = ModuleType("postalign.utils.group_by_codons")
+    utils_group.group_by_codons = group_by_codons  # type: ignore[attr-defined]
+
+    def codon_align(
+        refseq: Any, queryseq: Any, **_kwargs: Any
+    ) -> tuple[Any, Any]:
+        """Mutate ``queryseq`` to emulate codon realignment."""
+        if hasattr(queryseq, "seqtext") and len(queryseq.seqtext) >= 3:
+            queryseq.seqtext[:3] = b"TTT"
+        return refseq, queryseq
+
+    def parse_gap_placement_score(_text: str) -> dict:
+        """Return an empty gap-placement score map."""
+        return {}
+
+    processors_codon = ModuleType("postalign.processors.codon_alignment")
+    processors_codon.codon_align = codon_align  # type: ignore[attr-defined]
+    processors_codon.parse_gap_placement_score = (
+        parse_gap_placement_score  # type: ignore[attr-defined]
+    )
+
+    class NAPosition:
+        """Minimal representation of a nucleotide position."""
+
+        @staticmethod
+        def init_from_bytes(b: bytearray) -> bytearray:
+            """Return a mutable copy of *b*."""
+            return bytearray(b)
+
+        @staticmethod
+        def as_bytes(seq: bytearray) -> bytes:
+            """Return ``seq`` as immutable bytes."""
+            return bytes(seq)
+
+    class Sequence:
+        """Simplified sequence container mimicking PostAlign's API."""
+
+        def __init__(
+            self,
+            header: str,
+            description: str,
+            seqtext: bytearray,
+            seqid: int,
+            seqtype: Any,
+            abs_seqstart: int,
+            skip_invalid: bool,
+        ) -> None:
+            self.header = header
+            self.description = description
+            self.seqtext = seqtext
+            self.seqid = seqid
+            self.seqtype = seqtype
+            self.abs_seqstart = abs_seqstart
+            self.skip_invalid = skip_invalid
+
+    models_seq = ModuleType("postalign.models.sequence")
+    models_seq.NAPosition = NAPosition  # type: ignore[attr-defined]
+    models_seq.Sequence = Sequence  # type: ignore[attr-defined]
+
+    modules = {
+        "postalign": postalign,
+        "postalign.utils": utils,
+        "postalign.utils.group_by_codons": utils_group,
+        "postalign.processors": processors,
+        "postalign.processors.codon_alignment": processors_codon,
+        "postalign.models": models,
+        "postalign.models.sequence": models_seq,
+    }
+
+    with patch.dict(sys.modules, modules):
+        yield

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock, mock_open
 import sys
 
 import pytest
+import typer
 
 from .mock_postalign import mock_postalign
 
@@ -24,8 +25,11 @@ from codfreq.align import (  # noqa: E402
     find_paired_fastqs,
     ivar_trim,
     cutadapt_trim,
+    align_with_profile,
+    align,
+    REQUIRED_PROFILE_VERSION,
 )
-from codfreq.enums import LogFormat  # noqa: E402
+from codfreq.enums import LogFormat, Program  # noqa: E402
 from codfreq.codfreq_types import PairedFASTQ  # noqa: E402
 from codfreq.cmdwrappers.fastp import FASTPConfig  # noqa: E402
 from codfreq.cmdwrappers.ivar import TrimConfig  # noqa: E402
@@ -188,3 +192,165 @@ def test_cutadapt_trim_json_logs(
         merged["pair"][0], result["pair"][0], **config
     )
     assert result["pair"][0].endswith("merged-trimed.fastq.gz")
+
+
+def test_find_paired_fastq_patterns_chunk_mismatch() -> None:
+    """Filename pairs with different chunk counts are treated as singles."""
+
+    files = ["a_extra_R1.fastq", "b_R2.fastq"]
+    patterns = list(find_paired_fastq_patterns(files, autopairing=True))
+    assert len(patterns) == 2
+    assert all(p["pair"][1] is None for p in patterns)
+
+
+def test_find_paired_fastq_patterns_multiple_marker_diffs() -> None:
+    """Pairs with more than one marker difference are rejected."""
+
+    files = ["s_R1_1_x.fastq", "s_R2_2_x.fastq"]
+    patterns = list(find_paired_fastq_patterns(files, autopairing=True))
+    assert len(patterns) == 2
+    assert all(p["pair"][1] is None for p in patterns)
+
+
+def test_ivar_trim_json_logs(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """ivar.trim emits structured JSON progress when requested."""
+
+    in_bam = str(tmp_path / "in.bam")
+    out_bam = str(tmp_path / "out.bam")
+    config: TrimConfig = {}
+    with patch("codfreq.align.ivar.trim") as mock_trim:
+        ivar_trim(in_bam, out_bam, config, LogFormat.json)
+    out = capsys.readouterr().out
+    assert '"command": "ivar"' in out
+    mock_trim.assert_called_once_with(in_bam, out_bam, **config)
+
+
+def test_cutadapt_trim_text_logs(tmp_path: Path) -> None:
+    """cutadapt.cutadapt emits human-readable progress in text mode."""
+
+    merged: PairedFASTQ = {
+        "name": "sample",
+        "pair": (str(tmp_path / "sample.merged.fastq.gz"), None),
+        "n": 1,
+    }
+    config: CutadaptConfig = {}
+    with (
+        patch("codfreq.align.cutadapt.cutadapt") as mock_cut,
+        patch("codfreq.align.rich.print") as mock_print,
+    ):
+        result = cutadapt_trim(merged, config, LogFormat.text)
+    mock_print.assert_any_call("Trimming sample using cutadapt...")
+    mock_cut.assert_called_once_with(
+        merged["pair"][0], result["pair"][0], **config
+    )
+    assert result["pair"][0].endswith("merged-trimed.fastq.gz")
+
+
+def test_align_with_profile_replaces_without_trim(tmp_path: Path) -> None:
+    """When no trimming is configured files are renamed after alignment."""
+
+    paired = {"name": "samp", "pair": ("r1.fq", "r2.fq"), "n": 2}
+    profile = {"fragmentConfig": [{"fragmentName": "F", "refSequence": "AAA"}]}
+    with (
+        patch("codfreq.align.fastp_preprocess", return_value=paired),
+        patch("codfreq.align.get_refinit", return_value=lambda x: None),
+        patch(
+            "codfreq.align.get_align",
+            return_value=MagicMock(),
+        ) as get_align,
+        patch("codfreq.align.os.replace") as mock_replace,
+        patch("codfreq.align.rich.print"),
+    ):
+        align_with_profile(
+            paired,
+            Program.minimap2,
+            profile,
+            LogFormat.text,
+            fastp_config={},
+            cutadapt_config=None,
+            ivar_trim_config=None,
+        )
+    get_align.return_value.assert_called_once()
+    assert mock_replace.call_count == 3
+
+
+def test_align_with_profile_trims_and_logs_json(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Alignment path uses cutadapt and ivar trimming when configured."""
+
+    paired = {"name": "samp", "pair": ("r1.fq", "r2.fq"), "n": 2}
+    profile = {"fragmentConfig": [{"fragmentName": "F", "refSequence": "AAA"}]}
+    with (
+        patch("codfreq.align.fastp_preprocess", return_value=paired),
+        patch("codfreq.align.cutadapt_trim", return_value=paired) as mock_cut,
+        patch("codfreq.align.get_refinit", return_value=lambda x: None),
+        patch("codfreq.align.get_align", return_value=MagicMock()),
+        patch("codfreq.align.ivar_trim") as mock_ivar,
+    ):
+        align_with_profile(
+            paired,
+            Program.bowtie2,
+            profile,
+            LogFormat.json,
+            fastp_config={},
+            cutadapt_config={},
+            ivar_trim_config={},
+        )
+    out = capsys.readouterr().out
+    assert '"op": "alignment"' in out
+    mock_cut.assert_called_once()
+    mock_ivar.assert_called_once()
+
+
+def test_align_aborts_on_profile_version_mismatch(tmp_path: Path) -> None:
+    """Profiles with wrong version trigger a ``typer.Abort``."""
+
+    profile = tmp_path / "p.json"
+    profile.write_text("{}")
+    with (
+        profile.open() as fp,
+        patch("codfreq.align.json.load", return_value={"version": "old"}),
+        patch("codfreq.align.rich.print") as mock_print,
+    ):
+        with pytest.raises(typer.Abort):
+            align(tmp_path, Program.bowtie2, fp, 1, LogFormat.text, True)
+    mock_print.assert_called_once()
+
+
+def test_align_runs_pipeline(tmp_path: Path) -> None:
+    """Core pipeline orchestrates alignment and codfreq generation."""
+
+    profile = tmp_path / "p.json"
+    profile.write_text("{}")
+    profile_obj = {"version": REQUIRED_PROFILE_VERSION, "fragmentConfig": []}
+    pairobj = {"name": "samp", "pair": ("r1", "r2"), "n": 2}
+    with (
+        profile.open() as fp,
+        patch("codfreq.align.json.load", return_value=profile_obj),
+        patch("codfreq.align.find_paired_fastqs", return_value=[pairobj]),
+        patch("codfreq.align.fastp.load_config", return_value={}),
+        patch("codfreq.align.cutadapt.load_config", return_value=None),
+        patch("codfreq.align.ivar.load_trim_config", return_value=None),
+        patch("codfreq.align.align_with_profile") as mock_align_profile,
+        patch(
+            "codfreq.align.name_codfreq",
+            return_value=str(tmp_path / "out.codfreq"),
+        ),
+        patch("codfreq.align.open", mock_open(), create=True),
+        patch("codfreq.align.csv.DictWriter") as mock_writer,
+        patch(
+            "codfreq.align.sam2codfreq_all",
+            return_value=[{"codon": b"AAA"}],
+        ),
+        patch(
+            "codfreq.align.create_untrans_region_consensus"
+        ) as mock_consensus,
+    ):
+        align(tmp_path, Program.minimap2, fp, 1, LogFormat.text, True)
+    mock_align_profile.assert_called_once()
+    mock_writer.return_value.writeheader.assert_called_once()
+    mock_writer.return_value.writerow.assert_called_once()
+    mock_consensus.assert_called_once()

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -22,16 +22,26 @@ from codfreq.align import (  # noqa: E402
     complete_paired_fastqs,
     fastp_preprocess,
     find_paired_fastqs,
+    ivar_trim,
+    cutadapt_trim,
 )
 from codfreq.enums import LogFormat  # noqa: E402
 from codfreq.codfreq_types import PairedFASTQ  # noqa: E402
 from codfreq.cmdwrappers.fastp import FASTPConfig  # noqa: E402
+from codfreq.cmdwrappers.ivar import TrimConfig  # noqa: E402
+from codfreq.cmdwrappers.cutadapt import CutadaptConfig  # noqa: E402
 
 
 def test_find_paired_marker_valid_and_invalid() -> None:
     """Markers are detected only for proper R1/R2 differences."""
     assert find_paired_marker("read_R1.fastq", "read_R2.fastq") == 6
     assert find_paired_marker("read1.fastq", "read3.fastq") == -1
+
+
+def test_find_paired_marker_rejects_invalid_patterns() -> None:
+    """Extra digits or multiple mismatches invalidate the marker."""
+    assert find_paired_marker("sample_R11.fastq", "sample_R12.fastq") == -1
+    assert find_paired_marker("1x1a", "2x2b") == -1
 
 
 def test_find_paired_fastq_patterns_autopairing() -> None:
@@ -56,6 +66,15 @@ def test_find_paired_fastq_patterns_no_autopair() -> None:
         {"name": "a", "pair": ("a.fastq", None), "n": 1},
         {"name": "b", "pair": ("b.fastq", None), "n": 1},
     ]
+
+
+def test_find_paired_fastq_patterns_invalid_pairs() -> None:
+    """Pairs with multiple differences are treated as singles."""
+    files = ["a_R1.fastq", "b_R2.fastq"]
+    patterns = list(find_paired_fastq_patterns(files, autopairing=True))
+    assert len(patterns) == 2
+    assert {p["pair"][0] for p in patterns} == set(files)
+    assert all(p["pair"][1] is None and p["n"] == 1 for p in patterns)
 
 
 def test_complete_paired_fastqs_expands_paths() -> None:
@@ -122,3 +141,50 @@ def test_find_paired_fastqs_reads_pairinfo(tmp_path: Path) -> None:
             "n": 1,
         }
     ]
+
+
+def test_find_paired_fastqs_scans_directory(tmp_path: Path) -> None:
+    """Directories without pairinfo are scanned for FASTQ files."""
+    (tmp_path / "sample_R1.fastq").write_text("")
+    (tmp_path / "sample_R2.fastq").write_text("")
+    (tmp_path / "single.fastq").write_text("")
+    results = list(find_paired_fastqs(str(tmp_path), autopairing=True))
+    assert len(results) == 2
+    pairinfo = tmp_path / "pairinfo.json"
+    assert pairinfo.is_file()
+
+
+def test_ivar_trim_logs_and_calls_wrapper(tmp_path: Path) -> None:
+    """ivar.trim is invoked and progress logged in text mode."""
+    in_bam = str(tmp_path / "input.bam")
+    out_bam = str(tmp_path / "output.bam")
+    config: TrimConfig = {}
+    with (
+        patch("codfreq.align.ivar.trim") as mock_trim,
+        patch("codfreq.align.rich.print") as mock_print,
+    ):
+        ivar_trim(in_bam, out_bam, config, LogFormat.text)
+    mock_trim.assert_called_once_with(in_bam, out_bam, **config)
+    mock_print.assert_any_call(
+        f"Trimming {os.path.basename(in_bam)} using ivar..."
+    )
+
+
+def test_cutadapt_trim_json_logs(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """cutadapt.cutadapt is called and emits JSON progress."""
+    merged: PairedFASTQ = {
+        "name": "sample",
+        "pair": (str(tmp_path / "sample.merged.fastq.gz"), None),
+        "n": 1,
+    }
+    config: CutadaptConfig = {}
+    with patch("codfreq.align.cutadapt.cutadapt") as mock_cut:
+        result = cutadapt_trim(merged, config, LogFormat.json)
+    out = capsys.readouterr().out
+    assert '"command": "cutadapt"' in out
+    mock_cut.assert_called_once_with(
+        merged["pair"][0], result["pair"][0], **config
+    )
+    assert result["pair"][0].endswith("merged-trimed.fastq.gz")

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -6,17 +6,26 @@ import json
 import os
 from pathlib import Path
 from unittest.mock import patch
+import sys
 
-from codfreq.align import (
+import pytest
+
+from .mock_postalign import mock_postalign
+
+_POSTALIGN = mock_postalign()
+_POSTALIGN.__enter__()
+sys.modules.pop("codfreq.codonalign_consensus", None)
+sys.modules.pop("codfreq.sam2codfreq", None)
+from codfreq.align import (  # noqa: E402
     find_paired_marker,
     find_paired_fastq_patterns,
     complete_paired_fastqs,
     fastp_preprocess,
     find_paired_fastqs,
 )
-from codfreq.enums import LogFormat
-from codfreq.codfreq_types import PairedFASTQ
-from codfreq.cmdwrappers.fastp import FASTPConfig
+from codfreq.enums import LogFormat  # noqa: E402
+from codfreq.codfreq_types import PairedFASTQ  # noqa: E402
+from codfreq.cmdwrappers.fastp import FASTPConfig  # noqa: E402
 
 
 def test_find_paired_marker_valid_and_invalid() -> None:
@@ -36,6 +45,16 @@ def test_find_paired_fastq_patterns_autopairing() -> None:
             "n": 2,
         },
         {"name": "single", "pair": ("single.fastq", None), "n": 1},
+    ]
+
+
+def test_find_paired_fastq_patterns_no_autopair() -> None:
+    """Without autopairing every file is treated as single-ended."""
+    files = ["a.fastq", "b.fastq"]
+    patterns = list(find_paired_fastq_patterns(files, autopairing=False))
+    assert patterns == [
+        {"name": "a", "pair": ("a.fastq", None), "n": 1},
+        {"name": "b", "pair": ("b.fastq", None), "n": 1},
     ]
 
 
@@ -70,6 +89,24 @@ def test_fastp_preprocess_invokes_wrapper(tmp_path: Path) -> None:
     mock_fastp.assert_called_once()
     mock_print.assert_any_call("Pre-processing sample using fastp...")
     assert result["pair"][0].endswith("sample.merged.fastq.gz")
+
+
+def test_fastp_preprocess_json_logs(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """JSON log format prints structured progress messages."""
+    pfq: PairedFASTQ = {
+        "name": "sample",
+        "pair": (str(tmp_path / "r1.fq"), str(tmp_path / "r2.fq")),
+        "n": 2,
+    }
+    config: FASTPConfig = {}
+    with patch("codfreq.align.fastp.fastp") as mock_fastp:
+        result = fastp_preprocess(pfq, config, LogFormat.json)
+    out = capsys.readouterr().out
+    assert '"op": "preprocess"' in out
+    assert result["pair"][0].endswith("sample.merged.fastq.gz")
+    mock_fastp.assert_called_once()
 
 
 def test_find_paired_fastqs_reads_pairinfo(tmp_path: Path) -> None:

--- a/tests/test_align_cli.py
+++ b/tests/test_align_cli.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
 import sys
@@ -40,3 +41,34 @@ def test_align_cli_invalid_log_format(tmp_path: Path) -> None:
         ],
     )
     assert result.exit_code != 0
+
+
+def test_align_cli_enable_profiling(tmp_path: Path) -> None:
+    """Profiling flag runs under cProfile and prints stats."""
+
+    profile = tmp_path / "profile.json"
+    profile.write_text("{}", encoding="utf-8")
+    runner = CliRunner()
+    prof_ctx = MagicMock()
+    prof_ctx.__enter__.return_value = prof_ctx
+    prof_ctx.__exit__.return_value = None
+    with (
+        patch("cProfile.Profile", return_value=prof_ctx) as prof_cls,
+        patch("pstats.Stats") as stats_cls,
+        patch("codfreq.align.align") as mock_align,
+    ):
+        result = runner.invoke(
+            align_app,
+            [
+                str(tmp_path),
+                "-p",
+                "bowtie2",
+                "-r",
+                str(profile),
+                "--enable-profiling",
+            ],
+        )
+    assert result.exit_code == 0
+    prof_cls.assert_called_once()
+    mock_align.assert_called_once()
+    stats_cls.return_value.print_stats.assert_called_once()

--- a/tests/test_align_cli.py
+++ b/tests/test_align_cli.py
@@ -1,8 +1,15 @@
 from pathlib import Path
 
 from typer.testing import CliRunner
+import sys
 
-from codfreq.align import app as align_app
+from .mock_postalign import mock_postalign
+
+_POSTALIGN = mock_postalign()
+_POSTALIGN.__enter__()
+sys.modules.pop("codfreq.codonalign_consensus", None)
+sys.modules.pop("codfreq.sam2codfreq", None)
+from codfreq.align import app as align_app  # noqa: E402
 
 
 def test_align_cli_invalid_program(tmp_path: Path) -> None:

--- a/tests/test_cmdwrappers_base.py
+++ b/tests/test_cmdwrappers_base.py
@@ -39,6 +39,14 @@ def test_raise_on_proc_error_raises() -> None:
     rich_print.assert_called_once()
 
 
+def test_raise_on_proc_error_noop() -> None:
+    """Zero return codes result in no output or exception."""
+    proc = MagicMock(returncode=0)
+    with patch("rich.print") as rich_print:
+        base.raise_on_proc_error(proc, "")
+    rich_print.assert_not_called()
+
+
 def test_decorator_registration() -> None:
     """Decorator helpers register functions for later lookup."""
     def func() -> None:

--- a/tests/test_codonalign_consensus.py
+++ b/tests/test_codonalign_consensus.py
@@ -1,111 +1,14 @@
 """Tests for codon-alignment helpers and consensus assembly."""
 
-import sys
-import types
 from collections import Counter
-from typing import Any
 from unittest.mock import patch
+import sys
 
-# Stub out postalign dependencies used by codonalign_consensus
-postalign = types.ModuleType("postalign")
-postalign.__path__ = []
-utils = types.ModuleType("postalign.utils")
-utils.__path__ = []
-processors = types.ModuleType("postalign.processors")
-processors.__path__ = []
-models = types.ModuleType("postalign.models")
-models.__path__ = []
+from .mock_postalign import mock_postalign
 
-sys.modules["postalign"] = postalign
-sys.modules["postalign.utils"] = utils
-sys.modules["postalign.processors"] = processors
-sys.modules["postalign.models"] = models
-
-# group_by_codons stub
-utils_group = types.ModuleType("postalign.utils.group_by_codons")
-
-
-def group_by_codons(
-    seq1: bytearray,
-    seq2: bytearray,
-) -> tuple[list[bytearray], list[bytearray]]:
-    """Group two sequences into codon-sized chunks."""
-
-    def chunk(seq: bytearray) -> list[bytearray]:
-        return [seq[i:i + 3] for i in range(0, len(seq), 3)]
-
-    return chunk(seq1), chunk(seq2)
-
-
-utils_group.group_by_codons = group_by_codons  # type: ignore[attr-defined]
-sys.modules["postalign.utils.group_by_codons"] = utils_group
-
-# codon_alignment stubs
-processors_codon = types.ModuleType("postalign.processors.codon_alignment")
-
-
-def codon_align(refseq: Any, queryseq: Any, **_kwargs: Any) -> tuple[Any, Any]:
-    """Pretend to realign codons by mutating the query sequence."""
-    if len(queryseq.seqtext) >= 3:
-        queryseq.seqtext[:3] = b"TTT"
-    return refseq, queryseq
-
-
-def parse_gap_placement_score(_text: str) -> dict:
-    """Return an empty gap-placement map for tests."""
-    return {}
-
-
-processors_codon.codon_align = codon_align  # type: ignore[attr-defined]
-processors_codon.parse_gap_placement_score = (  # type: ignore[attr-defined]
-    parse_gap_placement_score
-)
-sys.modules["postalign.processors.codon_alignment"] = processors_codon
-
-# sequence model stubs
-models_seq = types.ModuleType("postalign.models.sequence")
-
-
-class NAPosition:
-    """Minimal representation of a nucleotide position."""
-
-    @staticmethod
-    def init_from_bytes(b: bytearray) -> bytearray:
-        return bytearray(b)
-
-    @staticmethod
-    def as_bytes(seq: bytearray) -> bytes:
-        return bytes(seq)
-
-
-class Sequence:
-    """Simple sequence container mimicking postalign's model."""
-
-    def __init__(
-        self,
-        header: str,
-        description: str,
-        seqtext: bytearray,
-        seqid: int,
-        seqtype: Any,
-        abs_seqstart: int,
-        skip_invalid: bool,
-    ) -> None:
-        self.header = header
-        self.description = description
-        self.seqtext = seqtext
-        self.seqid = seqid
-        self.seqtype = seqtype
-        self.abs_seqstart = abs_seqstart
-        self.skip_invalid = skip_invalid
-
-
-models_seq.NAPosition = NAPosition  # type: ignore[attr-defined]
-models_seq.Sequence = Sequence  # type: ignore[attr-defined]
-sys.modules["postalign.models.sequence"] = models_seq
-
+_POSTALIGN = mock_postalign()
+_POSTALIGN.__enter__()
 sys.modules.pop("codfreq.codonalign_consensus", None)
-
 from codfreq.codonalign_consensus import (  # noqa: E402
     aapos_to_napos,
     assemble_alignment,
@@ -115,7 +18,6 @@ from codfreq.codonalign_consensus import (  # noqa: E402
 
 def test_aapos_to_napos_across_ranges() -> None:
     """AA positions map correctly across multiple reference ranges."""
-
     refranges = [(1, 3), (10, 18)]
     assert aapos_to_napos(1, refranges) == 1
     assert aapos_to_napos(2, refranges) == 10
@@ -125,7 +27,6 @@ def test_aapos_to_napos_across_ranges() -> None:
 
 def test_assemble_alignment_handles_codon_sizes() -> None:
     """Consensus assembly pads or trims codons to fit the reference."""
-
     codonstat = {
         ("F", 1): Counter({b"AA": 1}),
         ("F", 3): Counter({b"AAAA": 1}),
@@ -144,7 +45,6 @@ def test_assemble_alignment_handles_codon_sizes() -> None:
 
 def test_codonalign_consensus_updates_counters() -> None:
     """Codon alignment config is honored and counters are updated."""
-
     codonstat = {
         ("frag", 1): Counter({b"AAA": 2}),
         ("skip", 1): Counter({b"CCC": 1}),
@@ -186,7 +86,6 @@ def test_codonalign_consensus_updates_counters() -> None:
 
 def test_assemble_alignment_returns_none_without_codons() -> None:
     """Fragments without codons yield ``None`` results."""
-
     codonstat: dict[tuple[str, int], Counter[bytes]] = {}
     fragment = {"fragmentName": "F", "refRanges": [(1, 3)]}
     refseq = bytearray(b"AAA")
@@ -200,7 +99,6 @@ def test_assemble_alignment_returns_none_without_codons() -> None:
 
 def test_codonalign_consensus_skips_empty_fragment() -> None:
     """Fragments without statistics are ignored."""
-
     codonstat: dict[tuple[str, int], Counter[bytes]] = {}
     quals: dict[tuple[str, int], Counter[bytes]] = {}
     ref = {"fragmentName": "ref", "refSequence": "AAA"}
@@ -212,7 +110,6 @@ def test_codonalign_consensus_skips_empty_fragment() -> None:
 
 def test_codonalign_consensus_alignment_failure_skips_fragment() -> None:
     """Alignment failures lead to early fragment skipping."""
-
     codonstat = {("frag", 1): Counter({b"AAA": 1})}
     quals = {("frag", 1): Counter({b"AAA": 1})}
     ref = {"fragmentName": "ref", "refSequence": "AAA"}
@@ -227,7 +124,6 @@ def test_codonalign_consensus_alignment_failure_skips_fragment() -> None:
 
 def test_codonalign_consensus_skips_positions_missing_quality() -> None:
     """Codon positions lacking quality scores are ignored."""
-
     codonstat = {
         ("frag", 1): Counter({b"AAA": 1}),
         ("frag", 2): Counter({b"CCC": 1}),

--- a/tests/test_posnas_io.py
+++ b/tests/test_posnas_io.py
@@ -80,6 +80,8 @@ def _decorator(*dargs: Any, **dkwargs: Any) -> Any:  # pragma: no cover
 cython_stub.ccall = _decorator  # type: ignore[attr-defined]
 cython_stub.inline = _decorator  # type: ignore[attr-defined]
 cython_stub.returns = lambda *a, **k: _decorator  # type: ignore[attr-defined]
+cython_stub.void = None  # type: ignore[attr-defined]
+cython_stub.cfunc = _decorator  # type: ignore[attr-defined]
 sys.modules["cython"] = cython_stub
 
 import codfreq.posnas as posnas  # noqa: E402
@@ -114,6 +116,16 @@ def test_get_posnas_between_skips_empty_reads() -> None:
     ]
     result = get_posnas_between("sample.sam", 0, 2)
     assert result == [("r1", [(1, 0, ord("A"), 10), (2, 0, ord("C"), 20)])]
+
+
+def test_get_posnas_between_stops_at_end() -> None:
+    """Processing halts once the file offset exceeds the end marker."""
+    AlignmentFile.reads = [
+        AlignedSegment("r1", "A", [10], [(0, 0)]),
+        AlignedSegment("r2", "C", [20], [(0, 1)]),
+    ]
+    result = get_posnas_between("sample.sam", 0, 1)
+    assert result == [("r1", [(1, 0, ord("A"), 10)])]
 
 
 def test_get_posnas_in_genome_region_skips_empty_reads() -> None:

--- a/tests/test_posnas_io.py
+++ b/tests/test_posnas_io.py
@@ -5,9 +5,9 @@ import types
 import importlib
 from array import array
 from typing import Any, Iterator
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
-# Stub pysam module
+# Build stub modules for third-party dependencies.
 pysam_stub = types.ModuleType("pysam")
 
 
@@ -65,9 +65,7 @@ class AlignmentFile:
 
 pysam_stub.AlignmentFile = AlignmentFile  # type: ignore[attr-defined]
 pysam_stub.AlignedSegment = AlignedSegment  # type: ignore[attr-defined]
-sys.modules["pysam"] = pysam_stub
 
-# Stub cython decorators
 cython_stub = types.ModuleType("cython")
 
 
@@ -82,15 +80,15 @@ cython_stub.inline = _decorator  # type: ignore[attr-defined]
 cython_stub.returns = lambda *a, **k: _decorator  # type: ignore[attr-defined]
 cython_stub.void = None  # type: ignore[attr-defined]
 cython_stub.cfunc = _decorator  # type: ignore[attr-defined]
-sys.modules["cython"] = cython_stub
 
-import codfreq.posnas as posnas  # noqa: E402
-importlib.reload(posnas)
-from codfreq.posnas import (  # noqa: E402
-    get_posnas_between,
-    get_posnas_in_genome_region,
-    iter_posnas,
-)
+with patch.dict(sys.modules, {"pysam": pysam_stub, "cython": cython_stub}):
+    import codfreq.posnas as posnas  # noqa: E402
+    importlib.reload(posnas)
+    from codfreq.posnas import (  # noqa: E402
+        get_posnas_between,
+        get_posnas_in_genome_region,
+        iter_posnas,
+    )
 
 
 def test_get_posnas_between_filters_quality() -> None:
@@ -120,6 +118,7 @@ def test_get_posnas_between_skips_empty_reads() -> None:
 
 def test_get_posnas_between_stops_at_end() -> None:
     """Processing halts once the file offset exceeds the end marker."""
+
     AlignmentFile.reads = [
         AlignedSegment("r1", "A", [10], [(0, 0)]),
         AlignedSegment("r2", "C", [20], [(0, 1)]),
@@ -235,6 +234,7 @@ def test_iter_posnas_without_progress() -> None:
 
 def test_iter_posnas_text_progress() -> None:
     """Text progress uses ``tqdm`` and sets the description."""
+
     AlignmentFile.reads = [
         AlignedSegment("r1", "AC", [10, 20], [(0, 0), (1, 1)]),
         AlignedSegment("r2", "GT", [30, 40], [(0, 2), (1, 3)]),

--- a/tests/test_sam2codfreq.py
+++ b/tests/test_sam2codfreq.py
@@ -2,9 +2,16 @@ from collections import Counter
 from typing import cast
 
 from unittest.mock import MagicMock, patch
+import sys
 
-import codfreq.sam2codfreq as s2c
-from codfreq.codfreq_types import (
+from .mock_postalign import mock_postalign
+
+_POSTALIGN = mock_postalign()
+_POSTALIGN.__enter__()
+sys.modules.pop("codfreq.codonalign_consensus", None)
+sys.modules.pop("codfreq.sam2codfreq", None)
+import codfreq.sam2codfreq as s2c  # noqa: E402
+from codfreq.codfreq_types import (  # noqa: E402
     DerivedFragmentConfig,
     MainFragmentConfig,
     Profile,

--- a/tests/test_sam2consensus.py
+++ b/tests/test_sam2consensus.py
@@ -22,6 +22,7 @@ cython_stub.cfunc = _decorator  # type: ignore[attr-defined]
 cython_stub.ccall = _decorator  # type: ignore[attr-defined]
 cython_stub.inline = _decorator  # type: ignore[attr-defined]
 cython_stub.returns = lambda *a, **k: _decorator  # type: ignore[attr-defined]
+cython_stub.void = None  # type: ignore[attr-defined]
 sys.modules["cython"] = cython_stub
 
 from codfreq.sam2consensus import (  # noqa: E402


### PR DESCRIPTION
## Summary
- add no-op coverage test for raise_on_proc_error
- verify get_posnas_between halts at end offset and patch cython stub
- cover alignment helper cases for non-autopairing and JSON logging
- include minimal PostAlign shims for type checking
- replace bundled PostAlign placeholders with reusable test stub
- mock PostAlign via patching instead of stubs

## Testing
- `pipenv run flake8 .`
- `pipenv run mypy --ignore-missing-imports --follow-imports=skip codfreq/cmdwrappers/base.py codfreq/posnas.py codfreq/align.py tests/test_cmdwrappers_base.py tests/test_posnas_io.py tests/test_align.py tests/test_align_cli.py tests/test_codonalign_consensus.py tests/test_sam2codfreq.py`
- `pipenv run pytest --cov=codfreq --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_6899214efdfc83248cc7a60678e7262e