### PR TITLE
refactor: migrate profile types to pydantic

### DIFF
--- a/codfreq/align.py
+++ b/codfreq/align.py
@@ -148,7 +148,7 @@ def find_paired_fastq_patterns(
                     if not invalid:
                         if fn1 > fn2:
                             # sort by filename
-                            fn1, fn2 = fn2, fn1
+                            fn1, fn2 = fn2, fn1  # pragma: no cover - swap
                         patterns[(
                             delimiter,
                             diffoffset,
@@ -426,11 +426,11 @@ def align_with_profile(
         refpath = os.path.join(tmpdir, 'ref.fas')
         refinit = get_refinit(program.value)
         alignfunc = get_align(program.value)
-        for config in profile['fragmentConfig']:
-            if 'refSequence' not in config:
+        for config in profile.fragmentConfig:
+            if config.refSequence is None:
                 continue  # pragma: no cover - missing refSequence
-            refname = config['fragmentName']
-            refseq = config['refSequence']
+            refname = config.fragmentName
+            refseq = config.refSequence
             with open(refpath, 'w') as fp:
                 fp.write(f'>{refname}\n{refseq}\n\n')
 
@@ -501,13 +501,14 @@ def align(
     :raises typer.Abort: If the profile version is incompatible.
     """
     row: CodFreqRow
-    profile_obj: Profile = json.load(profile)
-    if profile_obj.get('version') != REQUIRED_PROFILE_VERSION:
+    profile_data = json.load(profile)
+    if profile_data.get('version') != REQUIRED_PROFILE_VERSION:
         rich.print(
             'Incompatible profile detected. Download the latest profile files '
             'from: https://github.com/hivdb/codfreq/tree/main/profiles',
             file=sys.stderr)
         raise typer.Abort()
+    profile_obj = Profile.model_validate(profile_data)
     paired_fastqs = list(find_paired_fastqs(str(workdir), autopairing))
 
     fastp_config: fastp.FASTPConfig = fastp.load_config(

--- a/codfreq/align.py
+++ b/codfreq/align.py
@@ -148,7 +148,7 @@ def find_paired_fastq_patterns(
                     if not invalid:
                         if fn1 > fn2:
                             # sort by filename
-                            fn1, fn2 = fn2, fn1  # pragma: no cover - swap
+                            fn1, fn2 = fn2, fn1
                         patterns[(
                             delimiter,
                             diffoffset,

--- a/codfreq/codfreq_types.py
+++ b/codfreq/codfreq_types.py
@@ -1,5 +1,5 @@
-from typing import TypedDict, Literal
-from pydantic import BaseModel
+from typing import TypedDict, Literal, Any
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 FASTQFileName = str
 Header = str
@@ -33,20 +33,22 @@ class MainFragmentConfig(BaseModel):
     :param fragmentName: Name of the fragment.
     :type fragmentName: Header
     :param refSequence: Reference nucleotide sequence.
-    :type refSequence: SeqText | None
+    :type refSequence: SeqText
     """
 
+    model_config = ConfigDict(frozen=True, extra='forbid')
+
     fragmentName: Header
-    refSequence: SeqText | None = None
+    refSequence: SeqText
 
 
 class CodonAlignmentConfig(BaseModel):
     """Configuration options for codon alignment.
 
     :param relRefStart: Start position relative to the reference.
-    :type relRefStart: NAPos | None
+    :type relRefStart: NAPos
     :param relRefEnd: End position relative to the reference.
-    :type relRefEnd: NAPos | None
+    :type relRefEnd: NAPos
     :param windowSize: Sliding window size in amino acids.
     :type windowSize: AAPos | None
     :param minGapDistance: Minimum nucleotide distance between gaps.
@@ -55,8 +57,10 @@ class CodonAlignmentConfig(BaseModel):
     :type relGapPlacementScore: str | None
     """
 
-    relRefStart: NAPos | None = None
-    relRefEnd: NAPos | None = None
+    model_config = ConfigDict(frozen=True)
+
+    relRefStart: NAPos
+    relRefEnd: NAPos
     windowSize: AAPos | None = None
     minGapDistance: NAPos | None = None
     relGapPlacementScore: str | None = None
@@ -72,17 +76,50 @@ class DerivedFragmentConfig(BaseModel):
     :param geneName: Gene identifier if any.
     :type geneName: GeneText | None
     :param refRanges: Reference coordinate ranges.
-    :type refRanges: list[NAPosRange] | None
+    :type refRanges: list[NAPosRange]
     :param codonAlignment: Codon alignment configuration or ``False`` to
         disable alignment.
-    :type codonAlignment: None | (Literal[False] | list[CodonAlignmentConfig])
+    :type codonAlignment: Literal[False] | list[CodonAlignmentConfig] | None
     """
+
+    model_config = ConfigDict(frozen=True)
 
     fragmentName: Header
     fromFragment: Header
     geneName: GeneText | None = None
-    refRanges: list[NAPosRange] | None = None
-    codonAlignment: None | (Literal[False] | list[CodonAlignmentConfig]) = None
+    refRanges: list[NAPosRange]
+    codonAlignment: Literal[False] | list[CodonAlignmentConfig] | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def merge_ref_ranges(cls, data: Any) -> Any:
+        """Merge ``refStart``/``refEnd`` into ``refRanges`` if provided.
+
+        :param data: Raw input data.
+        :type data: Any
+        :returns: Normalized data with ``refRanges`` populated.
+        :rtype: Any
+        """
+
+        if isinstance(data, dict):
+            refstart = data.pop("refStart", None)
+            refend = data.pop("refEnd", None)
+            if (
+                "refRanges" not in data
+                and isinstance(refstart, int)
+                and isinstance(refend, int)
+            ):
+                data["refRanges"] = [(refstart, refend)]
+        return data
+
+    @field_validator("refRanges")
+    @classmethod
+    def ensure_ref_ranges(cls, value: list[NAPosRange]) -> list[NAPosRange]:
+        """Ensure ``refRanges`` is not empty."""
+
+        if not value:
+            raise ValueError("refRanges cannot be empty")
+        return value
 
 
 FragmentConfig = MainFragmentConfig | DerivedFragmentConfig
@@ -135,9 +172,11 @@ class Profile(BaseModel):
     :type sequenceAssemblyConfig: list[SequenceAssemblyConfig]
     """
 
-    version: str = ''
-    fragmentConfig: list[FragmentConfig] = []
-    sequenceAssemblyConfig: list[SequenceAssemblyConfig] = []
+    model_config = ConfigDict(frozen=True)
+
+    version: str
+    fragmentConfig: list[FragmentConfig]
+    sequenceAssemblyConfig: list[SequenceAssemblyConfig]
 
 
 class CodFreqRow(TypedDict):

--- a/codfreq/codfreq_types.py
+++ b/codfreq/codfreq_types.py
@@ -1,4 +1,5 @@
 from typing import TypedDict, Literal
+from pydantic import BaseModel
 
 FASTQFileName = str
 Header = str
@@ -26,39 +27,87 @@ class Sequence(TypedDict):
     sequence: SeqText
 
 
-class MainFragmentConfig(TypedDict):
+class MainFragmentConfig(BaseModel):
+    """Reference fragment configuration.
+
+    :param fragmentName: Name of the fragment.
+    :type fragmentName: Header
+    :param refSequence: Reference nucleotide sequence.
+    :type refSequence: SeqText | None
+    """
+
     fragmentName: Header
-    refSequence: SeqText
+    refSequence: SeqText | None = None
 
 
-class CodonAlignmentConfig(TypedDict, total=False):
-    relRefStart: NAPos
-    relRefEnd: NAPos
-    windowSize: AAPos | None
-    minGapDistance: NAPos | None
-    relGapPlacementScore: str | None
+class CodonAlignmentConfig(BaseModel):
+    """Configuration options for codon alignment.
+
+    :param relRefStart: Start position relative to the reference.
+    :type relRefStart: NAPos | None
+    :param relRefEnd: End position relative to the reference.
+    :type relRefEnd: NAPos | None
+    :param windowSize: Sliding window size in amino acids.
+    :type windowSize: AAPos | None
+    :param minGapDistance: Minimum nucleotide distance between gaps.
+    :type minGapDistance: NAPos | None
+    :param relGapPlacementScore: Relative gap placement score string.
+    :type relGapPlacementScore: str | None
+    """
+
+    relRefStart: NAPos | None = None
+    relRefEnd: NAPos | None = None
+    windowSize: AAPos | None = None
+    minGapDistance: NAPos | None = None
+    relGapPlacementScore: str | None = None
 
 
-class DerivedFragmentConfig(TypedDict, total=False):
+class DerivedFragmentConfig(BaseModel):
+    """Fragment derived from a reference fragment.
+
+    :param fragmentName: Name of the fragment.
+    :type fragmentName: Header
+    :param fromFragment: Source reference fragment name.
+    :type fromFragment: Header
+    :param geneName: Gene identifier if any.
+    :type geneName: GeneText | None
+    :param refRanges: Reference coordinate ranges.
+    :type refRanges: list[NAPosRange] | None
+    :param codonAlignment: Codon alignment configuration or ``False`` to
+        disable alignment.
+    :type codonAlignment: None | (Literal[False] | list[CodonAlignmentConfig])
+    """
+
     fragmentName: Header
     fromFragment: Header
-    refSequence: None
-    geneName: GeneText | None
-    refRanges: list[NAPosRange]
-    codonAlignment: None | (
-        Literal[False] | list[CodonAlignmentConfig]
-    )
+    geneName: GeneText | None = None
+    refRanges: list[NAPosRange] | None = None
+    codonAlignment: None | (Literal[False] | list[CodonAlignmentConfig]) = None
 
 
 FragmentConfig = MainFragmentConfig | DerivedFragmentConfig
 
 
-class SequenceAssemblyConfig(TypedDict):
-    name: str | None
-    geneName: str | None
-    fromFragment: str | None
-    refStart: int | None
-    refEnd: int | None
+class SequenceAssemblyConfig(BaseModel):
+    """Configuration for assembling sequences from fragments.
+
+    :param name: Name of the assembly region.
+    :type name: str | None
+    :param geneName: Associated gene name.
+    :type geneName: str | None
+    :param fromFragment: Source fragment name.
+    :type fromFragment: str | None
+    :param refStart: Start position in reference coordinates.
+    :type refStart: int | None
+    :param refEnd: End position in reference coordinates.
+    :type refEnd: int | None
+    """
+
+    name: str | None = None
+    geneName: str | None = None
+    fromFragment: str | None = None
+    refStart: int | None = None
+    refEnd: int | None = None
 
 
 class NARegionConfig(TypedDict):
@@ -75,10 +124,20 @@ class RegionalConsensus(TypedDict):
     consensus: str
 
 
-class Profile(TypedDict):
-    version: str
-    fragmentConfig: list[FragmentConfig]
-    sequenceAssemblyConfig: list[SequenceAssemblyConfig]
+class Profile(BaseModel):
+    """Top level profile configuration.
+
+    :param version: Profile schema version.
+    :type version: str
+    :param fragmentConfig: Fragment configuration list.
+    :type fragmentConfig: list[FragmentConfig]
+    :param sequenceAssemblyConfig: Assembly region configuration list.
+    :type sequenceAssemblyConfig: list[SequenceAssemblyConfig]
+    """
+
+    version: str = ''
+    fragmentConfig: list[FragmentConfig] = []
+    sequenceAssemblyConfig: list[SequenceAssemblyConfig] = []
 
 
 class CodFreqRow(TypedDict):

--- a/codfreq/sam2codfreq.py
+++ b/codfreq/sam2codfreq.py
@@ -4,17 +4,12 @@ from tqdm import tqdm  # type: ignore
 from collections import Counter
 from more_itertools import unique_everseen
 
-from typing import (
-    Any,
-    Mapping
-)
-from pydantic import BaseModel
+from typing import Any
 from concurrent.futures import ProcessPoolExecutor
 
 from .codfreq_types import (
     Header,
     AAPos,
-    NAPosRange,
     Profile,
     GeneText,
     CodFreqRow,
@@ -44,6 +39,7 @@ CODFREQ_HEADER: list[str] = [
     'total_quality_score'
 ]
 
+
 ENCODING: str = 'UTF-8'
 
 
@@ -51,54 +47,20 @@ ENCODING: str = 'UTF-8'
 @cython.inline
 @cython.returns(list)
 def build_fragment_intervals(
-    fragments: list[DerivedFragmentConfig | Mapping[str, Any]]
+    fragments: list[DerivedFragmentConfig]
 ) -> list[FragmentInterval]:
     """Extract fragment reference intervals for codon processing.
 
     :param fragments: Fragment configurations to convert.
-    :type fragments: list[DerivedFragmentConfig | Mapping[str, Any]]
+    :type fragments: list[DerivedFragmentConfig]
     :returns: Intervals paired with fragment names.
     :rtype: list[FragmentInterval]
     """
 
-    intervals: list[FragmentInterval] = []
-    for fragment in fragments:
-        if isinstance(fragment, DerivedFragmentConfig):
-            ranges = fragment.refRanges or []
-            name = fragment.fragmentName
-        else:
-            ranges = fragment.get('refRanges', [])
-            name = fragment.get('fragmentName', '')
-        intervals.append((ranges, name))
-    return intervals
-
-
-@cython.cfunc
-@cython.inline
-@cython.returns(list)
-def get_ref_ranges(config: Mapping[str, Any] | BaseModel) -> list[NAPosRange]:
-    """Normalize reference range definitions.
-
-    :param config: Fragment or region configuration.
-    :type config: Mapping[str, Any] | BaseModel
-    :returns: List of reference coordinate ranges.
-    :rtype: list[NAPosRange]
-    """
-
-    if isinstance(config, BaseModel):
-        refstart = getattr(config, 'refStart', None)
-        refend = getattr(config, 'refEnd', None)
-        orig_refranges = getattr(config, 'refRanges', None)
-    else:
-        refstart = config.get('refStart')
-        refend = config.get('refEnd')
-        orig_refranges = config.get('refRanges')
-    refranges: list[NAPosRange] = []
-    if isinstance(orig_refranges, list):
-        refranges = [(start, end) for start, end in orig_refranges]
-    elif isinstance(refstart, int) and isinstance(refend, int):
-        refranges = [(refstart, refend)]
-    return refranges
+    return [
+        (fragment.refRanges, fragment.fragmentName)
+        for fragment in fragments
+    ]
 
 
 @cython.cfunc
@@ -127,17 +89,8 @@ def get_ref_fragments(
     for config in profile.fragmentConfig:
         if not isinstance(config, DerivedFragmentConfig):
             continue
-        refranges = get_ref_ranges(config)
-        if not refranges:
-            continue  # pragma: no cover - validated above
-        derived = DerivedFragmentConfig(
-            fragmentName=config.fragmentName,
-            fromFragment=config.fromFragment,
-            geneName=config.geneName,
-            refRanges=refranges,
-            codonAlignment=config.codonAlignment,
-        )
-        ref_fragments[config.fromFragment]['fragments'].append(derived)
+        refranges = config.refRanges
+        ref_fragments[config.fromFragment]['fragments'].append(config)
         frag_size_lookup[config.fragmentName] = sum(
             (end - start + 1) for start, end in refranges
         ) // 3
@@ -155,7 +108,7 @@ def get_ref_fragments(
         if refname not in frag_gene_lookup:
             frag_gene_lookup[refname] = []
         frag_gene_lookup[refname].append((gene, gene_offsets[gene]))
-        gene_offsets[gene] += frag_size_lookup.get(refname, 0)
+        gene_offsets[gene] += frag_size_lookup[refname]
 
     return [
         (refname, pair['ref'], pair['fragments'])

--- a/codfreq/sam2codfreq.py
+++ b/codfreq/sam2codfreq.py
@@ -6,8 +6,9 @@ from more_itertools import unique_everseen
 
 from typing import (
     Any,
-    Literal
+    Mapping
 )
+from pydantic import BaseModel
 from concurrent.futures import ProcessPoolExecutor
 
 from .codfreq_types import (
@@ -22,7 +23,6 @@ from .codfreq_types import (
     FASTQFileName,
     FragmentConfig,
     MainFragmentConfig,
-    CodonAlignmentConfig,
     DerivedFragmentConfig
 )
 from .sam2codfreq_types import (
@@ -51,23 +51,48 @@ ENCODING: str = 'UTF-8'
 @cython.inline
 @cython.returns(list)
 def build_fragment_intervals(
-    fragments: list[DerivedFragmentConfig]
+    fragments: list[DerivedFragmentConfig | Mapping[str, Any]]
 ) -> list[FragmentInterval]:
-    """Extract fragment reference intervals for codon processing."""
+    """Extract fragment reference intervals for codon processing.
 
-    return [(
-        fragment['refRanges'],
-        fragment['fragmentName']
-    ) for fragment in fragments]
+    :param fragments: Fragment configurations to convert.
+    :type fragments: list[DerivedFragmentConfig | Mapping[str, Any]]
+    :returns: Intervals paired with fragment names.
+    :rtype: list[FragmentInterval]
+    """
+
+    intervals: list[FragmentInterval] = []
+    for fragment in fragments:
+        if isinstance(fragment, DerivedFragmentConfig):
+            ranges = fragment.refRanges or []
+            name = fragment.fragmentName
+        else:
+            ranges = fragment.get('refRanges', [])
+            name = fragment.get('fragmentName', '')
+        intervals.append((ranges, name))
+    return intervals
 
 
 @cython.cfunc
 @cython.inline
 @cython.returns(list)
-def get_ref_ranges(config: dict) -> list[NAPosRange]:
-    refstart = config.get('refStart')
-    refend = config.get('refEnd')
-    orig_refranges = config.get('refRanges')
+def get_ref_ranges(config: Mapping[str, Any] | BaseModel) -> list[NAPosRange]:
+    """Normalize reference range definitions.
+
+    :param config: Fragment or region configuration.
+    :type config: Mapping[str, Any] | BaseModel
+    :returns: List of reference coordinate ranges.
+    :rtype: list[NAPosRange]
+    """
+
+    if isinstance(config, BaseModel):
+        refstart = getattr(config, 'refStart', None)
+        refend = getattr(config, 'refEnd', None)
+        orig_refranges = getattr(config, 'refRanges', None)
+    else:
+        refstart = config.get('refStart')
+        refend = config.get('refEnd')
+        orig_refranges = config.get('refRanges')
     refranges: list[NAPosRange] = []
     if isinstance(orig_refranges, list):
         refranges = [(start, end) for start, end in orig_refranges]
@@ -90,84 +115,47 @@ def get_ref_fragments(
     FragmentGeneLookup
 ]:
     refname: str
-    codon_alignment: None | (
-        Literal[False] |
-        list[CodonAlignmentConfig]
-    )
-    cda: CodonAlignmentConfig
     config: FragmentConfig
     ref_fragments: dict[Header, TypedRefFragment] = {}
     frag_size_lookup: dict[Header, AAPos] = {}
-    for config in profile['fragmentConfig']:
-        refname = config['fragmentName']
-        refseq = config.get('refSequence')
-        if isinstance(refseq, str):
-            ref_fragments[refname] = {
-                'ref': {
-                    'fragmentName': refname,
-                    'refSequence': refseq
-                },
+    for config in profile.fragmentConfig:
+        if isinstance(config, MainFragmentConfig):
+            ref_fragments[config.fragmentName] = {
+                'ref': config,
                 'fragments': []
             }
-    for config in profile['fragmentConfig']:
-        refname = config['fragmentName']
-        fromref = config.get('fromFragment')
-        gene = config.get('geneName')
+    for config in profile.fragmentConfig:
+        if not isinstance(config, DerivedFragmentConfig):
+            continue
         refranges = get_ref_ranges(config)
-        codon_alignment_raw: Any = config.get('codonAlignment')
-        codon_alignment = None
-        if isinstance(codon_alignment_raw, list):
-            codon_alignment = []
-            for one in codon_alignment_raw:
-                cda = {}
-                if 'relRefStart' in one:
-                    cda['relRefStart'] = one['relRefStart']
-                if 'relRefEnd' in one:
-                    cda['relRefEnd'] = one['relRefEnd']
-                if 'windowSize' in one:
-                    cda['windowSize'] = one['windowSize']
-                if 'minGapDistance' in one:
-                    cda['minGapDistance'] = one['minGapDistance']
-                if 'relGapPlacementScore' in one:
-                    cda['relGapPlacementScore'] = one['relGapPlacementScore']
-                codon_alignment.append(cda)
-        elif codon_alignment_raw is False:
-            codon_alignment = False
-
-        if (
-            isinstance(fromref, str) and
-            (gene is None or isinstance(gene, str)) and
-            refranges
-        ):
-            ref_fragments[fromref]['fragments'].append({
-                'fragmentName': refname,
-                'fromFragment': fromref,
-                'geneName': gene,
-                'refRanges': refranges,
-                'codonAlignment': codon_alignment
-            })
-            frag_size_lookup[refname] = sum(
-                (end - start + 1) for start, end in refranges
-            ) // 3
+        if not refranges:
+            continue  # pragma: no cover - validated above
+        derived = DerivedFragmentConfig(
+            fragmentName=config.fragmentName,
+            fromFragment=config.fromFragment,
+            geneName=config.geneName,
+            refRanges=refranges,
+            codonAlignment=config.codonAlignment,
+        )
+        ref_fragments[config.fromFragment]['fragments'].append(derived)
+        frag_size_lookup[config.fragmentName] = sum(
+            (end - start + 1) for start, end in refranges
+        ) // 3
 
     # build frag_gene_lookup
     gene_offsets: dict[GeneText, AAPos] = {}
     frag_gene_lookup: FragmentGeneLookup = {}
-    for config in profile['fragmentConfig']:
-        refname = config['fragmentName']
-        gene = config.get('geneName')
-
+    for config in profile.fragmentConfig:
+        gene = getattr(config, 'geneName', None)
         if not isinstance(gene, str):
             continue
-
+        refname = config.fragmentName
         if gene not in gene_offsets:
             gene_offsets[gene] = 0
-
         if refname not in frag_gene_lookup:
             frag_gene_lookup[refname] = []
-
         frag_gene_lookup[refname].append((gene, gene_offsets[gene]))
-        gene_offsets[gene] += frag_size_lookup[refname]
+        gene_offsets[gene] += frag_size_lookup.get(refname, 0)
 
     return [
         (refname, pair['ref'], pair['fragments'])

--- a/codfreq/sam2consensus.py
+++ b/codfreq/sam2consensus.py
@@ -8,7 +8,8 @@ from .codfreq_types import (
     FragmentConfig,
     SequenceAssemblyConfig,
     NARegionConfig,
-    RegionalConsensus
+    RegionalConsensus,
+    DerivedFragmentConfig,
 )
 from .posnas import get_posnas_in_genome_region
 
@@ -133,33 +134,33 @@ def create_untrans_region_consensus(
     region: SequenceAssemblyConfig
 
     results: list[RegionalConsensus] = []
-    for fragment in profile['fragmentConfig']:
-        if 'fromFragment' in fragment:
+    for fragment in profile.fragmentConfig:
+        if isinstance(fragment, DerivedFragmentConfig):
             continue
-        refname = fragment['fragmentName']
+        refname = fragment.fragmentName
         samfile = name_bamfile(seqname, refname, is_trimmed=True)
-        for region in profile['sequenceAssemblyConfig']:
-            if region.get('fromFragment') != refname:
+        for region in profile.sequenceAssemblyConfig:
+            if region.fromFragment != refname:
                 continue
-            if 'name' not in region or region['name'] is None:
+            if region.name is None:
                 continue
-            if (
-                'fromFragment' not in region or region['fromFragment'] is None
-            ):  # pragma: no cover - validated above
+            if region.fromFragment is None:
+                continue  # pragma: no cover - validated above
+            if region.refStart is None:
                 continue
-            if 'refStart' not in region or region['refStart'] is None:
-                continue
-            if 'refEnd' not in region or region['refEnd'] is None:
+            if region.refEnd is None:
                 continue
 
-            results.append(sam2consensus(
-                samfile,
-                {
-                    'name': region['name'],
-                    'fromFragment': region['fromFragment'],
-                    'refStart': region['refStart'],
-                    'refEnd': region['refEnd']
-                }
-            ))
+            results.append(
+                sam2consensus(
+                    samfile,
+                    {
+                        'name': region.name,
+                        'fromFragment': region.fromFragment,
+                        'refStart': region.refStart,
+                        'refEnd': region.refEnd,
+                    },
+                )
+            )
     with open(f'{seqname}.untrans.json', 'w') as fp:
         json.dump(results, fp)

--- a/codfreq/sam2consensus.py
+++ b/codfreq/sam2consensus.py
@@ -140,12 +140,12 @@ def create_untrans_region_consensus(
         refname = fragment.fragmentName
         samfile = name_bamfile(seqname, refname, is_trimmed=True)
         for region in profile.sequenceAssemblyConfig:
+            if region.fromFragment is None:
+                continue
             if region.fromFragment != refname:
                 continue
             if region.name is None:
                 continue
-            if region.fromFragment is None:
-                continue  # pragma: no cover - validated above
             if region.refStart is None:
                 continue
             if region.refEnd is None:

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -23,7 +23,7 @@ from codfreq.align import (
     REQUIRED_PROFILE_VERSION,
 )
 from codfreq.enums import LogFormat, Program  # noqa: E402
-from codfreq.codfreq_types import PairedFASTQ  # noqa: E402
+from codfreq.codfreq_types import PairedFASTQ, Profile  # noqa: E402
 from codfreq.cmdwrappers.fastp import FASTPConfig  # noqa: E402
 from codfreq.cmdwrappers.ivar import TrimConfig  # noqa: E402
 from codfreq.cmdwrappers.cutadapt import CutadaptConfig  # noqa: E402
@@ -245,7 +245,9 @@ def test_align_with_profile_replaces_without_trim(tmp_path: Path) -> None:
     """When no trimming is configured files are renamed after alignment."""
 
     paired = {"name": "samp", "pair": ("r1.fq", "r2.fq"), "n": 2}
-    profile = {"fragmentConfig": [{"fragmentName": "F", "refSequence": "AAA"}]}
+    profile = Profile.model_validate(
+        {"fragmentConfig": [{"fragmentName": "F", "refSequence": "AAA"}]}
+    )
     with (
         patch("codfreq.align.fastp_preprocess", return_value=paired),
         patch("codfreq.align.get_refinit", return_value=lambda x: None),
@@ -275,7 +277,9 @@ def test_align_with_profile_trims_and_logs_json(
     """Alignment path uses cutadapt and ivar trimming when configured."""
 
     paired = {"name": "samp", "pair": ("r1.fq", "r2.fq"), "n": 2}
-    profile = {"fragmentConfig": [{"fragmentName": "F", "refSequence": "AAA"}]}
+    profile = Profile.model_validate(
+        {"fragmentConfig": [{"fragmentName": "F", "refSequence": "AAA"}]}
+    )
     with (
         patch("codfreq.align.fastp_preprocess", return_value=paired),
         patch("codfreq.align.cutadapt_trim", return_value=paired) as mock_cut,

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -74,6 +74,20 @@ def test_find_paired_fastq_patterns_invalid_pairs() -> None:
     assert all(p["pair"][1] is None and p["n"] == 1 for p in patterns)
 
 
+def test_find_paired_fastq_patterns_sorts_pairs() -> None:
+    """Input order does not affect output pair ordering."""
+
+    files = ["sample_R2.fastq", "sample_R1.fastq"]
+    patterns = list(find_paired_fastq_patterns(files, autopairing=True))
+    assert patterns == [
+        {
+            "name": "sample",
+            "pair": ("sample_R1.fastq", "sample_R2.fastq"),
+            "n": 2,
+        }
+    ]
+
+
 def test_complete_paired_fastqs_expands_paths() -> None:
     """Relative paths are joined with the directory path."""
     pairs: list[PairedFASTQ] = [
@@ -244,9 +258,13 @@ def test_cutadapt_trim_text_logs(tmp_path: Path) -> None:
 def test_align_with_profile_replaces_without_trim(tmp_path: Path) -> None:
     """When no trimming is configured files are renamed after alignment."""
 
-    paired = {"name": "samp", "pair": ("r1.fq", "r2.fq"), "n": 2}
+    paired: PairedFASTQ = {"name": "samp", "pair": ("r1.fq", "r2.fq"), "n": 2}
     profile = Profile.model_validate(
-        {"fragmentConfig": [{"fragmentName": "F", "refSequence": "AAA"}]}
+        {
+            "version": "1",
+            "fragmentConfig": [{"fragmentName": "F", "refSequence": "AAA"}],
+            "sequenceAssemblyConfig": [],
+        }
     )
     with (
         patch("codfreq.align.fastp_preprocess", return_value=paired),
@@ -276,9 +294,13 @@ def test_align_with_profile_trims_and_logs_json(
 ) -> None:
     """Alignment path uses cutadapt and ivar trimming when configured."""
 
-    paired = {"name": "samp", "pair": ("r1.fq", "r2.fq"), "n": 2}
+    paired: PairedFASTQ = {"name": "samp", "pair": ("r1.fq", "r2.fq"), "n": 2}
     profile = Profile.model_validate(
-        {"fragmentConfig": [{"fragmentName": "F", "refSequence": "AAA"}]}
+        {
+            "version": "1",
+            "fragmentConfig": [{"fragmentName": "F", "refSequence": "AAA"}],
+            "sequenceAssemblyConfig": [],
+        }
     )
     with (
         patch("codfreq.align.fastp_preprocess", return_value=paired),
@@ -322,7 +344,11 @@ def test_align_runs_pipeline(tmp_path: Path) -> None:
 
     profile = tmp_path / "p.json"
     profile.write_text("{}")
-    profile_obj = {"version": REQUIRED_PROFILE_VERSION, "fragmentConfig": []}
+    profile_obj = {
+        "version": REQUIRED_PROFILE_VERSION,
+        "fragmentConfig": [],
+        "sequenceAssemblyConfig": [],
+    }
     pairobj = {"name": "samp", "pair": ("r1", "r2"), "n": 2}
     with (
         profile.open() as fp,

--- a/tests/test_sam2codfreq.py
+++ b/tests/test_sam2codfreq.py
@@ -1,9 +1,12 @@
 """Tests for :mod:`codfreq.sam2codfreq`."""
 
 from collections import Counter
-from typing import cast
+from typing import Literal, cast
 
 from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
 
 import codfreq.sam2codfreq as s2c
 from codfreq.codfreq_types import (
@@ -13,23 +16,52 @@ from codfreq.codfreq_types import (
 )
 
 
-def test_build_fragment_intervals_and_get_ref_ranges() -> None:
+def test_build_fragment_intervals() -> None:
     fragments = [
-        {"refRanges": [(1, 3), (5, 7)], "fragmentName": "fragA"},
-        {"refRanges": [(8, 9)], "fragmentName": "fragB"},
+        DerivedFragmentConfig(
+            fragmentName="fragA",
+            fromFragment="refA",
+            refRanges=[(1, 3), (5, 7)],
+        ),
+        DerivedFragmentConfig(
+            fragmentName="fragB",
+            fromFragment="refA",
+            refRanges=[(8, 9)],
+        ),
     ]
     assert s2c.build_fragment_intervals(fragments) == [
         ([(1, 3), (5, 7)], "fragA"),
         ([(8, 9)], "fragB"),
     ]
 
-    assert s2c.get_ref_ranges({"refRanges": [(1, 3)]}) == [(1, 3)]
-    assert s2c.get_ref_ranges({"refStart": 4, "refEnd": 6}) == [(4, 6)]
+
+def test_derived_fragment_config_merges_refstart_refend() -> None:
+    frag = DerivedFragmentConfig.model_validate(
+        {
+            "fragmentName": "fragC",
+            "fromFragment": "refA",
+            "refStart": 4,
+            "refEnd": 6,
+        }
+    )
+    assert frag.refRanges == [(4, 6)]
+
+
+def test_derived_fragment_config_requires_ref_ranges() -> None:
+    with pytest.raises(ValidationError):
+        DerivedFragmentConfig.model_validate(
+            {
+                "fragmentName": "fragD",
+                "fromFragment": "refA",
+                "refRanges": [],
+            }
+        )
 
 
 def test_get_ref_fragments() -> None:
     profile = Profile.model_validate(
         {
+            "version": "1",
             "fragmentConfig": [
                 {"fragmentName": "refA", "refSequence": "AAA"},
                 {
@@ -54,7 +86,8 @@ def test_get_ref_fragments() -> None:
                     "refRanges": [(4, 6)],
                     "codonAlignment": False,
                 },
-            ]
+            ],
+            "sequenceAssemblyConfig": [],
         }
     )
     refs, lookup = s2c.get_ref_fragments(profile)
@@ -135,6 +168,7 @@ def test_sam2codfreq_all() -> None:
     ):
         profile = Profile.model_validate(
             {
+                "version": "1",
                 "fragmentConfig": [
                     {"fragmentName": "refA", "refSequence": "AAA"},
                     {
@@ -143,7 +177,8 @@ def test_sam2codfreq_all() -> None:
                         "geneName": "geneX",
                         "refRanges": [(1, 3)],
                     },
-                ]
+                ],
+                "sequenceAssemblyConfig": [],
             }
         )
 
@@ -173,7 +208,7 @@ def test_sam2codfreq_accumulates_and_reports_progress() -> None:
         def __enter__(self) -> "DummyExecutor":
             return self
 
-        def __exit__(self, *exc: object) -> bool:
+        def __exit__(self, *exc: object) -> Literal[False]:
             return False
 
         def map(self, func, *args):  # type: ignore[no-untyped-def]
@@ -255,7 +290,7 @@ def test_sam2codfreq_supports_json_log_format() -> None:
         def __enter__(self) -> "DummyExecutor":
             return self
 
-        def __exit__(self, *exc: object) -> bool:
+        def __exit__(self, *exc: object) -> Literal[False]:
             return False
 
         def map(self, func, *args):  # type: ignore[no-untyped-def]

--- a/tests/test_sam2codfreq.py
+++ b/tests/test_sam2codfreq.py
@@ -6,7 +6,11 @@ from typing import cast
 from unittest.mock import MagicMock, patch
 
 import codfreq.sam2codfreq as s2c
-from codfreq.codfreq_types import Profile
+from codfreq.codfreq_types import (
+    Profile,
+    MainFragmentConfig,
+    DerivedFragmentConfig,
+)
 
 
 def test_build_fragment_intervals_and_get_ref_ranges() -> None:
@@ -24,38 +28,42 @@ def test_build_fragment_intervals_and_get_ref_ranges() -> None:
 
 
 def test_get_ref_fragments() -> None:
-    profile = {
-        "fragmentConfig": [
-            {"fragmentName": "refA", "refSequence": "AAA"},
-            {
-                "fragmentName": "fragA",
-                "fromFragment": "refA",
-                "geneName": "geneX",
-                "refRanges": [(1, 3)],
-                "codonAlignment": [{
-                    "relRefStart": 1,
-                    "relRefEnd": 3,
-                    "windowSize": 3,
-                    "minGapDistance": 5,
-                    "relGapPlacementScore": "0:0-1=1",
-                }],
-            },
-            {
-                "fragmentName": "fragB",
-                "fromFragment": "refA",
-                "geneName": "geneY",
-                "refRanges": [(4, 6)],
-                "codonAlignment": False,
-            },
-        ]
-    }
-    refs, lookup = s2c.get_ref_fragments(profile)
-    assert refs[0][2][0]["codonAlignment"][0]["relRefEnd"] == 3
-    assert refs[0][2][0]["codonAlignment"][0]["minGapDistance"] == 5
-    assert (
-        refs[0][2][0]["codonAlignment"][0]["relGapPlacementScore"] == "0:0-1=1"
+    profile = Profile.model_validate(
+        {
+            "fragmentConfig": [
+                {"fragmentName": "refA", "refSequence": "AAA"},
+                {
+                    "fragmentName": "fragA",
+                    "fromFragment": "refA",
+                    "geneName": "geneX",
+                    "refRanges": [(1, 3)],
+                    "codonAlignment": [
+                        {
+                            "relRefStart": 1,
+                            "relRefEnd": 3,
+                            "windowSize": 3,
+                            "minGapDistance": 5,
+                            "relGapPlacementScore": "0:0-1=1",
+                        }
+                    ],
+                },
+                {
+                    "fragmentName": "fragB",
+                    "fromFragment": "refA",
+                    "geneName": "geneY",
+                    "refRanges": [(4, 6)],
+                    "codonAlignment": False,
+                },
+            ]
+        }
     )
-    assert refs[0][2][1]["codonAlignment"] is False
+    refs, lookup = s2c.get_ref_fragments(profile)
+    assert refs[0][2][0].codonAlignment[0].relRefEnd == 3
+    assert refs[0][2][0].codonAlignment[0].minGapDistance == 5
+    assert (
+        refs[0][2][0].codonAlignment[0].relGapPlacementScore == "0:0-1=1"
+    )
+    assert refs[0][2][1].codonAlignment is False
     assert lookup["fragB"] == [("geneY", 0)]
 
 
@@ -125,8 +133,7 @@ def test_sam2codfreq_all() -> None:
     ), patch(
         "codfreq.sam2codfreq.name_bamfile", return_value="file.bam"
     ):
-        profile = cast(
-            Profile,
+        profile = Profile.model_validate(
             {
                 "fragmentConfig": [
                     {"fragmentName": "refA", "refSequence": "AAA"},
@@ -137,7 +144,7 @@ def test_sam2codfreq_all() -> None:
                         "refRanges": [(1, 3)],
                     },
                 ]
-            },
+            }
         )
 
         rows = s2c.sam2codfreq_all("sample", (None, None), profile, workers=1)
@@ -196,13 +203,13 @@ def test_sam2codfreq_accumulates_and_reports_progress() -> None:
 
     progress = MagicMock()
 
-    ref = {"fragmentName": "refA", "refSequence": "AAA"}
+    ref = MainFragmentConfig(fragmentName="refA", refSequence="AAA")
     fragments = [
-        {
-            "fragmentName": "fragA",
-            "fromFragment": "refA",
-            "refRanges": [(1, 3)],
-        }
+        DerivedFragmentConfig(
+            fragmentName="fragA",
+            fromFragment="refA",
+            refRanges=[(1, 3)],
+        )
     ]
 
     with (
@@ -265,13 +272,13 @@ def test_sam2codfreq_supports_json_log_format() -> None:
 
     json_progress = MagicMock()
 
-    ref = {"fragmentName": "refA", "refSequence": "AAA"}
+    ref = MainFragmentConfig(fragmentName="refA", refSequence="AAA")
     fragments = [
-        {
-            "fragmentName": "fragA",
-            "fromFragment": "refA",
-            "refRanges": [(1, 3)],
-        }
+        DerivedFragmentConfig(
+            fragmentName="fragA",
+            fromFragment="refA",
+            refRanges=[(1, 3)],
+        )
     ]
 
     with (

--- a/tests/test_sam2consensus.py
+++ b/tests/test_sam2consensus.py
@@ -131,8 +131,12 @@ def test_create_untrans_region_consensus_writes_results(
     profile_dict: dict[str, Any] = {
         "version": "1",
         "fragmentConfig": [
-            {"fragmentName": "F1"},
-            {"fragmentName": "F2", "fromFragment": "other"},
+            {"fragmentName": "F1", "refSequence": "AAA"},
+            {
+                "fragmentName": "F2",
+                "fromFragment": "other",
+                "refRanges": [(1, 2)],
+            },
         ],
         "sequenceAssemblyConfig": [
             {
@@ -205,3 +209,31 @@ def test_create_untrans_region_consensus_writes_results(
     m.assert_called_once_with("seq1.untrans.json", "w")
     written = "".join(call.args[0] for call in m().write.call_args_list)
     assert json.loads(written) == [result_cons]
+
+
+@patch("codfreq.sam2consensus.sam2consensus")
+@patch("codfreq.sam2consensus.name_bamfile")
+def test_create_untrans_region_consensus_skips_missing_fromfragment(
+    mock_name_bamfile: MagicMock,
+    mock_sam2consensus: MagicMock,
+) -> None:
+    """Regions lacking ``fromFragment`` are ignored."""
+
+    profile = Profile.model_validate(
+        {
+            "version": "1",
+            "fragmentConfig": [{"fragmentName": "F1", "refSequence": "AAA"}],
+            "sequenceAssemblyConfig": [
+                {
+                    "name": "R1",
+                    "refStart": 1,
+                    "refEnd": 2,
+                }
+            ],
+        }
+    )
+    mock_name_bamfile.return_value = "file.bam"
+    m = mock_open()
+    with patch("codfreq.sam2consensus.open", m, create=True):
+        create_untrans_region_consensus("seq1", profile)
+    mock_sam2consensus.assert_not_called()

--- a/tests/test_sam2consensus.py
+++ b/tests/test_sam2consensus.py
@@ -185,7 +185,7 @@ def test_create_untrans_region_consensus_writes_results(
             ),
         ],
     }
-    profile = cast(Profile, profile_dict)
+    profile = Profile.model_validate(profile_dict)
     mock_name_bamfile.return_value = "file.bam"
     result_cons = {
         "name": "R1",


### PR DESCRIPTION
## Summary
- refactor profile-related types to Pydantic models
- update consumers and tests for new profile models

## Testing
- `flake8 .`
- `mypy codfreq/align.py codfreq/codfreq_types.py codfreq/sam2codfreq.py codfreq/sam2consensus.py tests/test_align.py tests/test_sam2codfreq.py tests/test_sam2consensus.py --ignore-missing-imports --follow-imports=skip` *(fails: Value of type "DerivedFragmentConfig" is not indexable ...)*
- `pytest --cov=codfreq --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_6899457ffed4832486090fd603b718fd