### PR TITLE
refactor: migrate TypedDicts to Pydantic models

### DIFF
--- a/codfreq/align.py
+++ b/codfreq/align.py
@@ -19,7 +19,7 @@ from collections.abc import Iterable, Generator
 import rich
 import typer
 
-from .codfreq_types import Profile, PairedFASTQ, CodFreqRow
+from .codfreq_types import Profile, PairedFASTQ, CodFreqRow, MainFragmentConfig
 
 from .sam2codfreq import (
     sam2codfreq_all,
@@ -178,36 +178,43 @@ def find_paired_fastq_patterns(
             if not invalid:
                 covered |= known
                 for pair in pairs:
-                    yield {
-                        'name': suggest_pair_name(pair, pattern),
-                        'pair': pair,
-                        'n': 2
-                    }
+                    yield PairedFASTQ(
+                        name=suggest_pair_name(pair, pattern),
+                        pair=pair,
+                        n=2
+                    )
     if len(filenames) > len(covered):
         remains: list[str] = sorted(set(filenames) - covered)
         pattern = ('', -1, -1, -1)
         for left in remains:
-            yield {
-                'name': suggest_pair_name((left, None), pattern),
-                'pair': (left, None),
-                'n': 1
-            }
+            yield PairedFASTQ(
+                name=suggest_pair_name((left, None), pattern),
+                pair=(left, None),
+                n=1
+            )
 
 
 def complete_paired_fastqs(
     paired_fastqs: Iterable[PairedFASTQ],
     dirpath: str
 ) -> Generator[PairedFASTQ, None, None]:
+    """Expand relative paths in :class:`PairedFASTQ` records."""
+
     for pairobj in paired_fastqs:
-        yield {
-            'name': os.path.join(dirpath, pairobj['name']),
-            'pair': (
-                os.path.join(dirpath, pairobj['pair'][0]),
-                os.path.join(dirpath, pairobj['pair'][1])
-                if pairobj['pair'][1] else None
+        pfq = (
+            pairobj
+            if isinstance(pairobj, PairedFASTQ)
+            else PairedFASTQ.model_validate(pairobj)
+        )
+        yield PairedFASTQ(
+            name=os.path.join(dirpath, pfq.name),
+            pair=(
+                os.path.join(dirpath, pfq.pair[0]),
+                os.path.join(dirpath, pfq.pair[1])
+                if pfq.pair[1] else None
             ),
-            'n': pairobj['n']
-        }
+            n=pfq.n
+        )
 
 
 def find_paired_fastqs(
@@ -217,10 +224,11 @@ def find_paired_fastqs(
     pairinfo: str = os.path.join(workdir, 'pairinfo.json')
     if os.path.isfile(pairinfo):
         with open(pairinfo) as fp:
-            yield from complete_paired_fastqs(
-                json.load(fp),
-                workdir
-            )
+            data = json.load(fp)
+        yield from complete_paired_fastqs(
+            [PairedFASTQ.model_validate(p) for p in data],
+            workdir
+        )
     else:
         pairinfo_list: list[PairedFASTQ] = []
         for dirpath, _, filenames in os.walk(workdir, followlinks=True):
@@ -240,7 +248,7 @@ def find_paired_fastqs(
                 rel_dirpath
             ))
         with open(pairinfo, 'w') as fp:
-            json.dump(pairinfo_list, fp, indent=2)
+            json.dump([p.model_dump() for p in pairinfo_list], fp, indent=2)
         yield from complete_paired_fastqs(pairinfo_list, workdir)
 
 
@@ -259,30 +267,29 @@ def fastp_preprocess(
     """
     if log_format == LogFormat.text:
         rich.print(
-            'Pre-processing {} using fastp...'
-            .format(paired_fastq['name'])
+            f'Pre-processing {paired_fastq.name} using fastp...'
         )
     else:
         print(json.dumps({
             'op': 'preprocess',
             'status': 'working',
-            'query': paired_fastq['name']
+            'query': paired_fastq.name
         }))
-    merged_fastq: PairedFASTQ = {
-        'name': paired_fastq['name'],
-        'pair': (
+    merged_fastq = PairedFASTQ(
+        name=paired_fastq.name,
+        pair=(
             os.path.join(
-                os.path.dirname(paired_fastq['pair'][0]),
-                '{}.merged.fastq.gz'.format(paired_fastq['name'])
+                os.path.dirname(paired_fastq.pair[0]),
+                f'{paired_fastq.name}.merged.fastq.gz'
             ),
             None
         ),
-        'n': 1
-    }
+        n=1
+    )
     fastp.fastp(
-        paired_fastq['pair'][0],
-        paired_fastq['pair'][1],
-        merged_fastq['pair'][0],
+        paired_fastq.pair[0],
+        paired_fastq.pair[1],
+        merged_fastq.pair[0],
         **fastp_config
     )
     if log_format == LogFormat.text:
@@ -291,7 +298,7 @@ def fastp_preprocess(
         print(json.dumps({
             'op': 'preprocess',
             'status': 'done',
-            'query': paired_fastq['name']
+            'query': paired_fastq.name
         }))
     return merged_fastq
 
@@ -353,18 +360,18 @@ def cutadapt_trim(
     :type log_format: LogFormat
     :returns: Metadata for the trimmed FASTQ file.
     """
-    name: str = merged_fastq['name']
-    output_fastq: PairedFASTQ = {
-        'name': merged_fastq['name'],
-        'pair': (
+    name: str = merged_fastq.name
+    output_fastq = PairedFASTQ(
+        name=merged_fastq.name,
+        pair=(
             os.path.join(
-                os.path.dirname(merged_fastq['pair'][0]),
-                '{}.merged-trimed.fastq.gz'.format(merged_fastq['name'])
+                os.path.dirname(merged_fastq.pair[0]),
+                f'{merged_fastq.name}.merged-trimed.fastq.gz'
             ),
             None
         ),
-        'n': 1
-    }
+        n=1
+    )
     if log_format == LogFormat.text:
         rich.print(
             'Trimming {} using cutadapt...'
@@ -378,8 +385,8 @@ def cutadapt_trim(
             'query': name
         }))
     cutadapt.cutadapt(
-        merged_fastq['pair'][0],
-        output_fastq['pair'][0],
+        merged_fastq.pair[0],
+        output_fastq.pair[0],
         **cutadapt_config
     )
     if log_format == LogFormat.text:
@@ -427,42 +434,42 @@ def align_with_profile(
         refinit = get_refinit(program.value)
         alignfunc = get_align(program.value)
         for config in profile.fragmentConfig:
-            if config.refSequence is None:
-                continue  # pragma: no cover - missing refSequence
+            if not isinstance(config, MainFragmentConfig):
+                continue  # pragma: no cover - skip non-main fragment
             refname = config.fragmentName
             refseq = config.refSequence
             with open(refpath, 'w') as fp:
                 fp.write(f'>{refname}\n{refseq}\n\n')
 
             orig_bamfile = name_bamfile(
-                paired_fastq['name'],
+                paired_fastq.name,
                 refname,
                 is_trimmed=False)
             trimmed_bamfile = name_bamfile(
-                paired_fastq['name'],
+                paired_fastq.name,
                 refname,
                 is_trimmed=True)
             refinit(refpath)
             if log_format == LogFormat.text:
                 rich.print(
                     'Aligning {} with {}...'
-                    .format(paired_fastq['name'], refname)
+                    .format(paired_fastq.name, refname)
                 )
             else:
                 print(json.dumps({
                     'op': 'alignment',
                     'status': 'working',
-                    'query': paired_fastq['name'],
+                    'query': paired_fastq.name,
                     'target': refname
                 }))
-            alignfunc(refpath, *paired_fastq['pair'], orig_bamfile)
+            alignfunc(refpath, *paired_fastq.pair, orig_bamfile)
             if log_format == LogFormat.text:
                 rich.print('Done')
             else:
                 print(json.dumps({
                     'op': 'alignment',
                     'status': 'done',
-                    'query': paired_fastq['name'],
+                    'query': paired_fastq.name,
                     'target': refname
                 }))
             if ivar_trim_config is None:
@@ -535,24 +542,24 @@ def align(
             cutadapt_config=cutadapt_config,
             ivar_trim_config=ivar_trim_config
         )
-        codfreqfile = name_codfreq(pairobj['name'])
+        codfreqfile = name_codfreq(pairobj.name)
         with open(codfreqfile, 'w', encoding='utf-8-sig') as fp:
             writer = csv.DictWriter(fp, CODFREQ_HEADER)
             writer.writeheader()
             for row in sam2codfreq_all(
-                name=pairobj['name'],
-                fnpair=pairobj['pair'],
+                name=pairobj.name,
+                fnpair=pairobj.pair,
                 profile=profile_obj,
                 workers=workers,
                 log_format=log_format
             ):
                 writer.writerow({
-                    **row,
-                    'codon': row['codon'].decode(ENCODING)
+                    **row.model_dump(),
+                    'codon': row.codon.decode(ENCODING)
                 })
 
         create_untrans_region_consensus(
-            pairobj['name'],
+            pairobj.name,
             profile_obj
         )
 

--- a/codfreq/codfreq_types.py
+++ b/codfreq/codfreq_types.py
@@ -1,4 +1,4 @@
-from typing import TypedDict, Literal, Any
+from typing import Literal, Any
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 FASTQFileName = str
@@ -16,13 +16,29 @@ MultiAAText = bytes
 NAPosRange = tuple[NAPos, NAPos]
 
 
-class PairedFASTQ(TypedDict):
+class PairedFASTQ(BaseModel):
+    """Metadata for a paired FASTQ sample.
+
+    :param name: Sample identifier.
+    :type name: Header
+    :param pair: Tuple of R1/R2 FASTQ filenames. ``None`` for single-end reads.
+    :type pair: tuple[FASTQFileName, FASTQFileName | None]
+    :param n: Number of FASTQ files in the pair.
+    :type n: int
+    """
+
+    model_config = ConfigDict(frozen=True, extra='forbid')
+
     name: Header
     pair: tuple[FASTQFileName, FASTQFileName | None]
     n: int
 
 
-class Sequence(TypedDict):
+class Sequence(BaseModel):
+    """FASTA sequence entry."""
+
+    model_config = ConfigDict(frozen=True, extra='forbid')
+
     header: Header
     sequence: SeqText
 
@@ -147,14 +163,22 @@ class SequenceAssemblyConfig(BaseModel):
     refEnd: int | None = None
 
 
-class NARegionConfig(TypedDict):
+class NARegionConfig(BaseModel):
+    """Definition of a nucleotide assembly region."""
+
+    model_config = ConfigDict(frozen=True, extra='forbid')
+
     name: str
     fromFragment: str
     refStart: int
     refEnd: int
 
 
-class RegionalConsensus(TypedDict):
+class RegionalConsensus(BaseModel):
+    """Consensus sequence for an assembly region."""
+
+    model_config = ConfigDict(frozen=True, extra='forbid')
+
     name: str
     refStart: NAPos
     refEnd: NAPos
@@ -179,7 +203,11 @@ class Profile(BaseModel):
     sequenceAssemblyConfig: list[SequenceAssemblyConfig]
 
 
-class CodFreqRow(TypedDict):
+class CodFreqRow(BaseModel):
+    """Single CodFreq output row."""
+
+    model_config = ConfigDict(frozen=True, extra='forbid')
+
     gene: GeneText
     position: AAPos
     total: int

--- a/codfreq/codfreq_types.py
+++ b/codfreq/codfreq_types.py
@@ -73,7 +73,7 @@ class CodonAlignmentConfig(BaseModel):
     :type relGapPlacementScore: str | None
     """
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra='forbid')
 
     relRefStart: NAPos
     relRefEnd: NAPos
@@ -98,7 +98,7 @@ class DerivedFragmentConfig(BaseModel):
     :type codonAlignment: Literal[False] | list[CodonAlignmentConfig] | None
     """
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra='forbid')
 
     fragmentName: Header
     fromFragment: Header
@@ -156,6 +156,8 @@ class SequenceAssemblyConfig(BaseModel):
     :type refEnd: int | None
     """
 
+    model_config = ConfigDict(frozen=True, extra='forbid')
+
     name: str | None = None
     geneName: str | None = None
     fromFragment: str | None = None
@@ -196,7 +198,7 @@ class Profile(BaseModel):
     :type sequenceAssemblyConfig: list[SequenceAssemblyConfig]
     """
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra='forbid')
 
     version: str
     fragmentConfig: list[FragmentConfig]
@@ -204,7 +206,21 @@ class Profile(BaseModel):
 
 
 class CodFreqRow(BaseModel):
-    """Single CodFreq output row."""
+    """Single CodFreq output row.
+
+    :param gene: Gene name.
+    :type gene: GeneText
+    :param position: Amino acid position.
+    :type position: AAPos
+    :param total: Total codons observed at the position.
+    :type total: int
+    :param codon: Codon sequence encoded as bytes.
+    :type codon: CodonText
+    :param count: Number of reads supporting the codon.
+    :type count: int
+    :param total_quality_score: Sum of base qualities supporting the codon.
+    :type total_quality_score: float
+    """
 
     model_config = ConfigDict(frozen=True, extra='forbid')
 
@@ -213,7 +229,7 @@ class CodFreqRow(BaseModel):
     total: int
     codon: CodonText
     count: int
-    total_quality_score: int
+    total_quality_score: float
 
 
 #                                 refStart refEnd

--- a/codfreq/codonalign_consensus.py
+++ b/codfreq/codonalign_consensus.py
@@ -9,7 +9,7 @@ from postalign.models.sequence import (
     NAPosition
 )
 from operator import itemgetter
-from typing import Any, Literal
+from typing import Literal
 from collections import Counter
 
 from .sam2codfreq_types import CodonCounterByFragPos
@@ -81,7 +81,7 @@ def aapos_to_napos(
 def assemble_alignment(
     codonstat_by_fragpos: CodonCounterByFragPos,
     refseq: bytearray,
-    fragment: DerivedFragmentConfig | dict[str, Any]
+    fragment: DerivedFragmentConfig
 ) -> tuple[
     Sequence | None,
     Sequence | None,
@@ -95,9 +95,8 @@ def assemble_alignment(
     :type codonstat_by_fragpos: CodonCounterByFragPos
     :param refseq: Reference nucleotide sequence for the main fragment.
     :type refseq: bytearray
-    :param fragment: Fragment configuration including reference ranges or a raw
-        mapping that can be validated into one.
-    :type fragment: DerivedFragmentConfig | dict[str, Any]
+    :param fragment: Fragment configuration including reference ranges.
+    :type fragment: DerivedFragmentConfig
     :returns: Tuple of reference sequence, query sequence and the first and
         last amino-acid positions represented. ``None`` values indicate that no
         codons were found for the fragment.
@@ -110,10 +109,6 @@ def assemble_alignment(
     cons_codon_bytes: bytes
     cons_codon_size: int
     codons: Counter[CodonText] | None
-    if not isinstance(fragment, DerivedFragmentConfig):
-        fragment = DerivedFragmentConfig.model_validate(
-            {"fromFragment": "", **fragment}
-        )
     fragment_name: Header = fragment.fragmentName
     frag_refranges: list[NAPosRange] = fragment.refRanges
     frag_refseq: bytearray = bytearray()
@@ -166,15 +161,15 @@ order_getter = itemgetter('count', 'total_quality_score')
 def codonalign_consensus(
     codonstat_by_fragpos: CodonCounterByFragPos,
     qualities_by_fragpos: CodonCounterByFragPos,
-    ref: MainFragmentConfig | dict[str, Any],
-    fragments: list[DerivedFragmentConfig | dict[str, Any]],
+    ref: MainFragmentConfig,
+    fragments: list[DerivedFragmentConfig],
 ) -> tuple[CodonCounterByFragPos, CodonCounterByFragPos]:
     """Derive codon consensus for aligned fragments.
 
-    :param ref: Reference fragment configuration or raw mapping.
-    :type ref: MainFragmentConfig | dict[str, Any]
-    :param fragments: Derived fragment configurations or raw mappings.
-    :type fragments: list[DerivedFragmentConfig | dict[str, Any]]
+    :param ref: Reference fragment configuration.
+    :type ref: MainFragmentConfig
+    :param fragments: Derived fragment configurations.
+    :type fragments: list[DerivedFragmentConfig]
     """
 
     fragment_name: Header
@@ -191,20 +186,8 @@ def codonalign_consensus(
     querycodon: list[NAPosition]
     codons: Counter[CodonText] | None
 
-    if not isinstance(ref, MainFragmentConfig):
-        ref = MainFragmentConfig.model_validate(ref)
-    fragments_validated = [
-        (
-            f
-            if isinstance(f, DerivedFragmentConfig)
-            else DerivedFragmentConfig.model_validate(
-                {"fromFragment": ref.fragmentName, **f}
-            )
-        )
-        for f in fragments
-    ]
     refseq: bytearray = bytearray(ref.refSequence, ENCODING)
-    for fragment in fragments_validated:
+    for fragment in fragments:
         fragment_name = fragment.fragmentName
         codon_align_config: None | (
             Literal[False] | list[CodonAlignmentConfig]

--- a/codfreq/codonalign_consensus.py
+++ b/codfreq/codonalign_consensus.py
@@ -9,9 +9,7 @@ from postalign.models.sequence import (
     NAPosition
 )
 from operator import itemgetter
-from typing import (
-    Literal
-)
+from typing import Any, Literal
 from collections import Counter
 
 from .sam2codfreq_types import CodonCounterByFragPos
@@ -83,7 +81,7 @@ def aapos_to_napos(
 def assemble_alignment(
     codonstat_by_fragpos: CodonCounterByFragPos,
     refseq: bytearray,
-    fragment: DerivedFragmentConfig
+    fragment: DerivedFragmentConfig | dict[str, Any]
 ) -> tuple[
     Sequence | None,
     Sequence | None,
@@ -97,8 +95,9 @@ def assemble_alignment(
     :type codonstat_by_fragpos: CodonCounterByFragPos
     :param refseq: Reference nucleotide sequence for the main fragment.
     :type refseq: bytearray
-    :param fragment: Fragment configuration including reference ranges.
-    :type fragment: DerivedFragmentConfig
+    :param fragment: Fragment configuration including reference ranges or a raw
+        mapping that can be validated into one.
+    :type fragment: DerivedFragmentConfig | dict[str, Any]
     :returns: Tuple of reference sequence, query sequence and the first and
         last amino-acid positions represented. ``None`` values indicate that no
         codons were found for the fragment.
@@ -167,10 +166,16 @@ order_getter = itemgetter('count', 'total_quality_score')
 def codonalign_consensus(
     codonstat_by_fragpos: CodonCounterByFragPos,
     qualities_by_fragpos: CodonCounterByFragPos,
-    ref: MainFragmentConfig,
-    fragments: list[DerivedFragmentConfig],
+    ref: MainFragmentConfig | dict[str, Any],
+    fragments: list[DerivedFragmentConfig | dict[str, Any]],
 ) -> tuple[CodonCounterByFragPos, CodonCounterByFragPos]:
-    """Derive codon consensus for aligned fragments."""
+    """Derive codon consensus for aligned fragments.
+
+    :param ref: Reference fragment configuration or raw mapping.
+    :type ref: MainFragmentConfig | dict[str, Any]
+    :param fragments: Derived fragment configurations or raw mappings.
+    :type fragments: list[DerivedFragmentConfig | dict[str, Any]]
+    """
 
     fragment_name: Header
     fragment: DerivedFragmentConfig
@@ -188,7 +193,7 @@ def codonalign_consensus(
 
     if not isinstance(ref, MainFragmentConfig):
         ref = MainFragmentConfig.model_validate(ref)
-    fragments = [
+    fragments_validated = [
         (
             f
             if isinstance(f, DerivedFragmentConfig)
@@ -199,7 +204,7 @@ def codonalign_consensus(
         for f in fragments
     ]
     refseq: bytearray = bytearray(ref.refSequence, ENCODING)
-    for fragment in fragments:
+    for fragment in fragments_validated:
         fragment_name = fragment.fragmentName
         codon_align_config: None | (
             Literal[False] | list[CodonAlignmentConfig]
@@ -210,7 +215,9 @@ def codonalign_consensus(
             continue
 
         if not codon_align_config:
-            codon_align_config = [CodonAlignmentConfig(relRefStart=0, relRefEnd=0)]
+            codon_align_config = [
+                CodonAlignmentConfig(relRefStart=0, relRefEnd=0)
+            ]
 
         # assemble consensus codon reads into pairwise alignment
         (frag_refseq_obj,

--- a/codfreq/codonalign_consensus.py
+++ b/codfreq/codonalign_consensus.py
@@ -111,8 +111,12 @@ def assemble_alignment(
     cons_codon_bytes: bytes
     cons_codon_size: int
     codons: Counter[CodonText] | None
-    fragment_name: Header = fragment['fragmentName']
-    frag_refranges: list[NAPosRange] = fragment['refRanges']
+    if not isinstance(fragment, DerivedFragmentConfig):
+        fragment = DerivedFragmentConfig.model_validate(
+            {"fromFragment": "", **fragment}
+        )
+    fragment_name: Header = fragment.fragmentName
+    frag_refranges: list[NAPosRange] = fragment.refRanges
     frag_refseq: bytearray = bytearray()
     frag_queryseq: bytearray = bytearray()
     refsize: int = sum(end - start + 1 for start, end in frag_refranges)
@@ -182,19 +186,31 @@ def codonalign_consensus(
     querycodon: list[NAPosition]
     codons: Counter[CodonText] | None
 
-    refseq: bytearray = bytearray(ref['refSequence'], ENCODING)
+    if not isinstance(ref, MainFragmentConfig):
+        ref = MainFragmentConfig.model_validate(ref)
+    fragments = [
+        (
+            f
+            if isinstance(f, DerivedFragmentConfig)
+            else DerivedFragmentConfig.model_validate(
+                {"fromFragment": ref.fragmentName, **f}
+            )
+        )
+        for f in fragments
+    ]
+    refseq: bytearray = bytearray(ref.refSequence, ENCODING)
     for fragment in fragments:
-        fragment_name = fragment['fragmentName']
+        fragment_name = fragment.fragmentName
         codon_align_config: None | (
             Literal[False] | list[CodonAlignmentConfig]
-        ) = fragment.get('codonAlignment')
+        ) = fragment.codonAlignment
 
         if codon_align_config is False:
             # skip this gene if explicitly defined codonAlignment=False
             continue
 
         if not codon_align_config:
-            codon_align_config = [{}]
+            codon_align_config = [CodonAlignmentConfig(relRefStart=0, relRefEnd=0)]
 
         # assemble consensus codon reads into pairwise alignment
         (frag_refseq_obj,
@@ -218,8 +234,8 @@ def codonalign_consensus(
 
         # apply codon alignment (CDA) to pairwise alignment
         for cda_config in codon_align_config:
-            refstart = cda_config.get('relRefStart', seq_refstart)
-            refend = cda_config.get('relRefEnd', seq_refend)
+            refstart = cda_config.relRefStart or seq_refstart
+            refend = cda_config.relRefEnd or seq_refend
 
             # Codon alignment shouldn't exceed query sequence boundary
             if refstart < seq_refend and refend > seq_refstart:
@@ -227,16 +243,15 @@ def codonalign_consensus(
                 refend = min(refend, seq_refend)
 
             # Load minGapDistance, windowSize and gapPlacementScore from config
-            min_gap_distance = cda_config.get(
-                'minGapDistance'
-            ) or CODON_ALIGN_MIN_GAP_DISTANCE
-            window_size = cda_config.get(
-                'windowSize'
-            ) or CODON_ALIGN_WINDOW_SIZE
+            min_gap_distance = (
+                cda_config.minGapDistance or CODON_ALIGN_MIN_GAP_DISTANCE
+            )
+            window_size = cda_config.windowSize or CODON_ALIGN_WINDOW_SIZE
             gap_placement_score: dict[
                 int, dict[tuple[int, int], int]
             ] = parse_gap_placement_score(
-                cda_config.get('relGapPlacementScore') or '')
+                cda_config.relGapPlacementScore or ''
+            )
 
             # perform postalign's codon_align
             (frag_refseq_obj,

--- a/codfreq/fastareader.py
+++ b/codfreq/fastareader.py
@@ -3,28 +3,39 @@ from .codfreq_types import Sequence
 
 
 def load(fp: TextIO) -> list[Sequence]:
+    """Load FASTA entries from a file-like object.
+
+    :param fp: Input stream positioned at a FASTA file.
+    :type fp: TextIO
+    :returns: Parsed sequence objects.
+    :rtype: list[Sequence]
+    """
+
     sequences: list[Sequence] = []
     header: str | None = None
     curseq: bytearray = bytearray()
     for line in fp:
         if line.startswith('>'):
             if header and curseq:
-                sequences.append({
-                    'header': header,
-                    'sequence': curseq.upper().decode('U8')
-                })
+                sequences.append(
+                    Sequence(
+                        header=header,
+                        sequence=curseq.upper().decode('U8')
+                    )
+                )
             header = line[1:].strip()
             curseq = bytearray()
         elif line.startswith('#'):
             continue
         else:
             curseq.extend(
-                line.strip()
-                .encode('ASCII', errors='ignore')
+                line.strip().encode('ASCII', errors='ignore')
             )
     if header and curseq:
-        sequences.append({
-            'header': header,
-            'sequence': curseq.upper().decode('U8')
-        })
+        sequences.append(
+            Sequence(
+                header=header,
+                sequence=curseq.upper().decode('U8')
+            )
+        )
     return sequences

--- a/codfreq/sam2codfreq.py
+++ b/codfreq/sam2codfreq.py
@@ -169,18 +169,20 @@ def get_codonfreq(
         for codon, count in codons.items():
             qua = qualities_by_fragpos[(fragment_name, refpos)][codon]
             for gene, gene_offset in frag_gene_lookup[fragment_name]:
-                rows.append({
-                    'gene': gene,
-                    'position': refpos + gene_offset,
-                    'total': total,
-                    'codon': codon,
-                    'count': count,
-                    'total_quality_score': round(qua, 2)
-                })
+                rows.append(
+                    CodFreqRow(
+                        gene=gene,
+                        position=refpos + gene_offset,
+                        total=total,
+                        codon=codon,
+                        count=count,
+                        total_quality_score=round(qua, 2)
+                    )
+                )
     rows.sort(key=lambda row: (
-        ordered_genes.index(row['gene']),
-        row['position'],
-        row['codon']
+        ordered_genes.index(row.gene),
+        row.position,
+        row.codon
     ))
     return rows
 

--- a/codfreq/sam2consensus.py
+++ b/codfreq/sam2consensus.py
@@ -41,9 +41,9 @@ def make_consensus(
     refpos: NAPos
     idx: int
 
-    name: str = region['name']
-    refpos_start: NAPos = region['refStart']
-    refpos_end: NAPos = region['refEnd']
+    name: str = region.name
+    refpos_start: NAPos = region.refStart
+    refpos_end: NAPos = region.refEnd
     consarr: bytearray = bytearray()
 
     for refpos in range(refpos_start, refpos_end + 1):
@@ -57,12 +57,12 @@ def make_consensus(
                 break
             consarr.append(na)
             idx += 1
-    return {
-        'name': name,
-        'refStart': refpos_start,
-        'refEnd': refpos_end,
-        'consensus': consarr.decode(ENCODING)
-    }
+    return RegionalConsensus(
+        name=name,
+        refStart=refpos_start,
+        refEnd=refpos_end,
+        consensus=consarr.decode(ENCODING)
+    )
 
 
 def sam2consensus(
@@ -86,9 +86,9 @@ def sam2consensus(
 
     for _, posnas in get_posnas_in_genome_region(
         sampath,
-        ref_name=region['fromFragment'],
-        ref_start=region['refStart'],
-        ref_end=region['refEnd']
+        ref_name=region.fromFragment,
+        ref_start=region.refStart,
+        ref_end=region.refEnd
     ):
         for refpos, idx, na, _ in posnas:
             nafreqs[(refpos, idx)][na] += 1
@@ -154,13 +154,13 @@ def create_untrans_region_consensus(
             results.append(
                 sam2consensus(
                     samfile,
-                    {
-                        'name': region.name,
-                        'fromFragment': region.fromFragment,
-                        'refStart': region.refStart,
-                        'refEnd': region.refEnd,
-                    },
+                    NARegionConfig(
+                        name=region.name,
+                        fromFragment=region.fromFragment,
+                        refStart=region.refStart,
+                        refEnd=region.refEnd,
+                    ),
                 )
             )
     with open(f'{seqname}.untrans.json', 'w') as fp:
-        json.dump(results, fp)
+        json.dump([r.model_dump() for r in results], fp)

--- a/codfreq/tests/__init__.py
+++ b/codfreq/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test modules for codfreq package."""

--- a/codfreq/tests/test_codfreq_types_validation.py
+++ b/codfreq/tests/test_codfreq_types_validation.py
@@ -1,0 +1,51 @@
+"""Validation tests for configuration models."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from codfreq.codfreq_types import (
+    CodonAlignmentConfig,
+    DerivedFragmentConfig,
+    SequenceAssemblyConfig,
+    Profile,
+)
+
+
+def test_codon_alignment_config_rejects_extra() -> None:
+    """``CodonAlignmentConfig`` raises on unknown fields."""
+    with pytest.raises(ValidationError):
+        CodonAlignmentConfig(  # type: ignore[call-arg]
+            relRefStart=1,
+            relRefEnd=2,
+            unknown=3,
+        )
+
+
+def test_derived_fragment_config_rejects_extra() -> None:
+    """``DerivedFragmentConfig`` raises on unknown fields."""
+    with pytest.raises(ValidationError):
+        DerivedFragmentConfig(  # type: ignore[call-arg]
+            fragmentName="frag",
+            fromFragment="ref",
+            refRanges=[(1, 2)],
+            unknown=5,
+        )
+
+
+def test_sequence_assembly_config_rejects_extra() -> None:
+    """``SequenceAssemblyConfig`` raises on unknown fields."""
+    with pytest.raises(ValidationError):
+        SequenceAssemblyConfig(name="a", unknown=1)  # type: ignore[call-arg]
+
+
+def test_profile_rejects_extra() -> None:
+    """``Profile`` raises on unknown fields."""
+    with pytest.raises(ValidationError):
+        Profile(  # type: ignore[call-arg]
+            version="1",
+            fragmentConfig=[],
+            sequenceAssemblyConfig=[],
+            unknown=1,
+        )

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -23,7 +23,11 @@ from codfreq.align import (
     REQUIRED_PROFILE_VERSION,
 )
 from codfreq.enums import LogFormat, Program  # noqa: E402
-from codfreq.codfreq_types import PairedFASTQ, Profile  # noqa: E402
+from codfreq.codfreq_types import (
+    PairedFASTQ,
+    Profile,
+    CodFreqRow,
+)  # noqa: E402
 from codfreq.cmdwrappers.fastp import FASTPConfig  # noqa: E402
 from codfreq.cmdwrappers.ivar import TrimConfig  # noqa: E402
 from codfreq.cmdwrappers.cutadapt import CutadaptConfig  # noqa: E402
@@ -45,7 +49,7 @@ def test_find_paired_fastq_patterns_autopairing() -> None:
     """Autopairing groups matching pairs and singles."""
     files = ["sample_R1.fastq", "sample_R2.fastq", "single.fastq"]
     patterns = list(find_paired_fastq_patterns(files, autopairing=True))
-    assert patterns == [
+    assert [p.model_dump() for p in patterns] == [
         {
             "name": "sample",
             "pair": ("sample_R1.fastq", "sample_R2.fastq"),
@@ -59,7 +63,7 @@ def test_find_paired_fastq_patterns_no_autopair() -> None:
     """Without autopairing every file is treated as single-ended."""
     files = ["a.fastq", "b.fastq"]
     patterns = list(find_paired_fastq_patterns(files, autopairing=False))
-    assert patterns == [
+    assert [p.model_dump() for p in patterns] == [
         {"name": "a", "pair": ("a.fastq", None), "n": 1},
         {"name": "b", "pair": ("b.fastq", None), "n": 1},
     ]
@@ -70,8 +74,8 @@ def test_find_paired_fastq_patterns_invalid_pairs() -> None:
     files = ["a_R1.fastq", "b_R2.fastq"]
     patterns = list(find_paired_fastq_patterns(files, autopairing=True))
     assert len(patterns) == 2
-    assert {p["pair"][0] for p in patterns} == set(files)
-    assert all(p["pair"][1] is None and p["n"] == 1 for p in patterns)
+    assert {p.pair[0] for p in patterns} == set(files)
+    assert all(p.pair[1] is None and p.n == 1 for p in patterns)
 
 
 def test_find_paired_fastq_patterns_sorts_pairs() -> None:
@@ -79,7 +83,7 @@ def test_find_paired_fastq_patterns_sorts_pairs() -> None:
 
     files = ["sample_R2.fastq", "sample_R1.fastq"]
     patterns = list(find_paired_fastq_patterns(files, autopairing=True))
-    assert patterns == [
+    assert [p.model_dump() for p in patterns] == [
         {
             "name": "sample",
             "pair": ("sample_R1.fastq", "sample_R2.fastq"),
@@ -91,10 +95,10 @@ def test_find_paired_fastq_patterns_sorts_pairs() -> None:
 def test_complete_paired_fastqs_expands_paths() -> None:
     """Relative paths are joined with the directory path."""
     pairs: list[PairedFASTQ] = [
-        {"name": "a", "pair": ("r1.fq", "r2.fq"), "n": 2}
+        PairedFASTQ(name="a", pair=("r1.fq", "r2.fq"), n=2)
     ]
     result = list(complete_paired_fastqs(pairs, "/work"))
-    assert result == [
+    assert [r.model_dump() for r in result] == [
         {
             "name": "/work/a",
             "pair": ("/work/r1.fq", "/work/r2.fq"),
@@ -105,11 +109,11 @@ def test_complete_paired_fastqs_expands_paths() -> None:
 
 def test_fastp_preprocess_invokes_wrapper(tmp_path: Path) -> None:
     """Fastp wrapper is called and merged filename returned."""
-    pfq: PairedFASTQ = {
-        "name": "sample",
-        "pair": (str(tmp_path / "r1.fq"), str(tmp_path / "r2.fq")),
-        "n": 2,
-    }
+    pfq = PairedFASTQ(
+        name="sample",
+        pair=(str(tmp_path / "r1.fq"), str(tmp_path / "r2.fq")),
+        n=2,
+    )
     config: FASTPConfig = {}
     with (
         patch("codfreq.align.fastp.fastp") as mock_fastp,
@@ -118,24 +122,24 @@ def test_fastp_preprocess_invokes_wrapper(tmp_path: Path) -> None:
         result = fastp_preprocess(pfq, config, LogFormat.text)
     mock_fastp.assert_called_once()
     mock_print.assert_any_call("Pre-processing sample using fastp...")
-    assert result["pair"][0].endswith("sample.merged.fastq.gz")
+    assert result.pair[0].endswith("sample.merged.fastq.gz")
 
 
 def test_fastp_preprocess_json_logs(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """JSON log format prints structured progress messages."""
-    pfq: PairedFASTQ = {
-        "name": "sample",
-        "pair": (str(tmp_path / "r1.fq"), str(tmp_path / "r2.fq")),
-        "n": 2,
-    }
+    pfq = PairedFASTQ(
+        name="sample",
+        pair=(str(tmp_path / "r1.fq"), str(tmp_path / "r2.fq")),
+        n=2,
+    )
     config: FASTPConfig = {}
     with patch("codfreq.align.fastp.fastp") as mock_fastp:
         result = fastp_preprocess(pfq, config, LogFormat.json)
     out = capsys.readouterr().out
     assert '"op": "preprocess"' in out
-    assert result["pair"][0].endswith("sample.merged.fastq.gz")
+    assert result.pair[0].endswith("sample.merged.fastq.gz")
     mock_fastp.assert_called_once()
 
 
@@ -145,7 +149,7 @@ def test_find_paired_fastqs_reads_pairinfo(tmp_path: Path) -> None:
     pairinfo = tmp_path / "pairinfo.json"
     pairinfo.write_text(json.dumps(data))
     results = list(find_paired_fastqs(str(tmp_path), autopairing=False))
-    assert results == [
+    assert [r.model_dump() for r in results] == [
         {
             "name": os.path.join(str(tmp_path), "samp"),
             "pair": (os.path.join(str(tmp_path), "a.fastq"), None),
@@ -185,20 +189,20 @@ def test_cutadapt_trim_json_logs(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """cutadapt.cutadapt is called and emits JSON progress."""
-    merged: PairedFASTQ = {
-        "name": "sample",
-        "pair": (str(tmp_path / "sample.merged.fastq.gz"), None),
-        "n": 1,
-    }
+    merged = PairedFASTQ(
+        name="sample",
+        pair=(str(tmp_path / "sample.merged.fastq.gz"), None),
+        n=1,
+    )
     config: CutadaptConfig = {}
     with patch("codfreq.align.cutadapt.cutadapt") as mock_cut:
         result = cutadapt_trim(merged, config, LogFormat.json)
     out = capsys.readouterr().out
     assert '"command": "cutadapt"' in out
     mock_cut.assert_called_once_with(
-        merged["pair"][0], result["pair"][0], **config
+        merged.pair[0], result.pair[0], **config
     )
-    assert result["pair"][0].endswith("merged-trimed.fastq.gz")
+    assert result.pair[0].endswith("merged-trimed.fastq.gz")
 
 
 def test_find_paired_fastq_patterns_chunk_mismatch() -> None:
@@ -207,7 +211,7 @@ def test_find_paired_fastq_patterns_chunk_mismatch() -> None:
     files = ["a_extra_R1.fastq", "b_R2.fastq"]
     patterns = list(find_paired_fastq_patterns(files, autopairing=True))
     assert len(patterns) == 2
-    assert all(p["pair"][1] is None for p in patterns)
+    assert all(p.pair[1] is None for p in patterns)
 
 
 def test_find_paired_fastq_patterns_multiple_marker_diffs() -> None:
@@ -216,7 +220,7 @@ def test_find_paired_fastq_patterns_multiple_marker_diffs() -> None:
     files = ["s_R1_1_x.fastq", "s_R2_2_x.fastq"]
     patterns = list(find_paired_fastq_patterns(files, autopairing=True))
     assert len(patterns) == 2
-    assert all(p["pair"][1] is None for p in patterns)
+    assert all(p.pair[1] is None for p in patterns)
 
 
 def test_ivar_trim_json_logs(
@@ -237,11 +241,11 @@ def test_ivar_trim_json_logs(
 def test_cutadapt_trim_text_logs(tmp_path: Path) -> None:
     """cutadapt.cutadapt emits human-readable progress in text mode."""
 
-    merged: PairedFASTQ = {
-        "name": "sample",
-        "pair": (str(tmp_path / "sample.merged.fastq.gz"), None),
-        "n": 1,
-    }
+    merged = PairedFASTQ(
+        name="sample",
+        pair=(str(tmp_path / "sample.merged.fastq.gz"), None),
+        n=1,
+    )
     config: CutadaptConfig = {}
     with (
         patch("codfreq.align.cutadapt.cutadapt") as mock_cut,
@@ -250,15 +254,15 @@ def test_cutadapt_trim_text_logs(tmp_path: Path) -> None:
         result = cutadapt_trim(merged, config, LogFormat.text)
     mock_print.assert_any_call("Trimming sample using cutadapt...")
     mock_cut.assert_called_once_with(
-        merged["pair"][0], result["pair"][0], **config
+        merged.pair[0], result.pair[0], **config
     )
-    assert result["pair"][0].endswith("merged-trimed.fastq.gz")
+    assert result.pair[0].endswith("merged-trimed.fastq.gz")
 
 
 def test_align_with_profile_replaces_without_trim(tmp_path: Path) -> None:
     """When no trimming is configured files are renamed after alignment."""
 
-    paired: PairedFASTQ = {"name": "samp", "pair": ("r1.fq", "r2.fq"), "n": 2}
+    paired = PairedFASTQ(name="samp", pair=("r1.fq", "r2.fq"), n=2)
     profile = Profile.model_validate(
         {
             "version": "1",
@@ -294,7 +298,7 @@ def test_align_with_profile_trims_and_logs_json(
 ) -> None:
     """Alignment path uses cutadapt and ivar trimming when configured."""
 
-    paired: PairedFASTQ = {"name": "samp", "pair": ("r1.fq", "r2.fq"), "n": 2}
+    paired = PairedFASTQ(name="samp", pair=("r1.fq", "r2.fq"), n=2)
     profile = Profile.model_validate(
         {
             "version": "1",
@@ -349,7 +353,7 @@ def test_align_runs_pipeline(tmp_path: Path) -> None:
         "fragmentConfig": [],
         "sequenceAssemblyConfig": [],
     }
-    pairobj = {"name": "samp", "pair": ("r1", "r2"), "n": 2}
+    pairobj = PairedFASTQ(name="samp", pair=("r1", "r2"), n=2)
     with (
         profile.open() as fp,
         patch("codfreq.align.json.load", return_value=profile_obj),
@@ -366,7 +370,16 @@ def test_align_runs_pipeline(tmp_path: Path) -> None:
         patch("codfreq.align.csv.DictWriter") as mock_writer,
         patch(
             "codfreq.align.sam2codfreq_all",
-            return_value=[{"codon": b"AAA"}],
+            return_value=[
+                CodFreqRow(
+                    gene="g",
+                    position=1,
+                    total=1,
+                    codon=b"AAA",
+                    count=1,
+                    total_quality_score=1,
+                )
+            ],
         ),
         patch(
             "codfreq.align.create_untrans_region_consensus"

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -377,7 +377,7 @@ def test_align_runs_pipeline(tmp_path: Path) -> None:
                     total=1,
                     codon=b"AAA",
                     count=1,
-                    total_quality_score=1,
+                    total_quality_score=1.0,
                 )
             ],
         ),

--- a/tests/test_codonalign_consensus.py
+++ b/tests/test_codonalign_consensus.py
@@ -2,10 +2,16 @@
 
 from collections import Counter
 from unittest.mock import patch
+
 from codfreq.codonalign_consensus import (
     aapos_to_napos,
     assemble_alignment,
     codonalign_consensus,
+)
+from codfreq.codfreq_types import (
+    MainFragmentConfig,
+    DerivedFragmentConfig,
+    CodonAlignmentConfig,
 )
 
 
@@ -24,7 +30,11 @@ def test_assemble_alignment_handles_codon_sizes() -> None:
         ("F", 1): Counter({b"AA": 1}),
         ("F", 3): Counter({b"AAAA": 1}),
     }
-    fragment = {"fragmentName": "F", "refRanges": [(1, 9)]}
+    fragment = DerivedFragmentConfig(
+        fragmentName="F",
+        fromFragment="ref",
+        refRanges=[(1, 9)]
+    )
     refseq = bytearray(b"AAACCCGGG")
 
     ref_obj, query_obj, first, last = assemble_alignment(
@@ -46,26 +56,28 @@ def test_codonalign_consensus_updates_counters() -> None:
         ("frag", 1): Counter({b"AAA": 5}),
         ("skip", 1): Counter({b"CCC": 3}),
     }
-    ref = {"fragmentName": "ref", "refSequence": "AAACCC"}
+    ref = MainFragmentConfig(fragmentName="ref", refSequence="AAACCC")
     fragments = [
-        {
-            "fragmentName": "skip",
-            "refRanges": [(1, 3)],
-            "codonAlignment": False,
-        },
-        {
-            "fragmentName": "frag",
-            "refRanges": [(1, 3)],
-            "codonAlignment": [
-                {
-                    "relRefStart": 0,
-                    "relRefEnd": 15,
-                    "minGapDistance": 5,
-                    "windowSize": 7,
-                    "relGapPlacementScore": "0:0-1=1",
-                }
+        DerivedFragmentConfig(
+            fragmentName="skip",
+            fromFragment="ref",
+            refRanges=[(1, 3)],
+            codonAlignment=False,
+        ),
+        DerivedFragmentConfig(
+            fragmentName="frag",
+            fromFragment="ref",
+            refRanges=[(1, 3)],
+            codonAlignment=[
+                CodonAlignmentConfig(
+                    relRefStart=0,
+                    relRefEnd=15,
+                    minGapDistance=5,
+                    windowSize=7,
+                    relGapPlacementScore="0:0-1=1",
+                )
             ],
-        },
+        ),
     ]
 
     codonalign_consensus(codonstat, quals, ref, fragments)
@@ -80,7 +92,11 @@ def test_codonalign_consensus_updates_counters() -> None:
 def test_assemble_alignment_returns_none_without_codons() -> None:
     """Fragments without codons yield ``None`` results."""
     codonstat: dict[tuple[str, int], Counter[bytes]] = {}
-    fragment = {"fragmentName": "F", "refRanges": [(1, 3)]}
+    fragment = DerivedFragmentConfig(
+        fragmentName="F",
+        fromFragment="ref",
+        refRanges=[(1, 3)]
+    )
     refseq = bytearray(b"AAA")
 
     ref_obj, query_obj, first, last = assemble_alignment(
@@ -94,8 +110,14 @@ def test_codonalign_consensus_skips_empty_fragment() -> None:
     """Fragments without statistics are ignored."""
     codonstat: dict[tuple[str, int], Counter[bytes]] = {}
     quals: dict[tuple[str, int], Counter[bytes]] = {}
-    ref = {"fragmentName": "ref", "refSequence": "AAA"}
-    fragments = [{"fragmentName": "frag", "refRanges": [(1, 3)]}]
+    ref = MainFragmentConfig(fragmentName="ref", refSequence="AAA")
+    fragments = [
+        DerivedFragmentConfig(
+            fragmentName="frag",
+            fromFragment="ref",
+            refRanges=[(1, 3)]
+        )
+    ]
 
     result = codonalign_consensus(codonstat, quals, ref, fragments)
     assert result == (codonstat, quals)
@@ -105,8 +127,14 @@ def test_codonalign_consensus_alignment_failure_skips_fragment() -> None:
     """Alignment failures lead to early fragment skipping."""
     codonstat = {("frag", 1): Counter({b"AAA": 1})}
     quals = {("frag", 1): Counter({b"AAA": 1})}
-    ref = {"fragmentName": "ref", "refSequence": "AAA"}
-    fragments = [{"fragmentName": "frag", "refRanges": [(1, 3)]}]
+    ref = MainFragmentConfig(fragmentName="ref", refSequence="AAA")
+    fragments = [
+        DerivedFragmentConfig(
+            fragmentName="frag",
+            fromFragment="ref",
+            refRanges=[(1, 3)]
+        )
+    ]
 
     with patch(
         "codfreq.codonalign_consensus.codon_align",
@@ -122,7 +150,15 @@ def test_codonalign_consensus_skips_positions_missing_quality() -> None:
         ("frag", 2): Counter({b"CCC": 1}),
     }
     quals = {("frag", 1): Counter({b"AAA": 1})}
-    ref = {"fragmentName": "ref", "refSequence": "AAA CCC".replace(" ", "")}
-    fragments = [{"fragmentName": "frag", "refRanges": [(1, 6)]}]
+    ref = MainFragmentConfig(
+        fragmentName="ref", refSequence="AAA CCC".replace(" ", "")
+    )
+    fragments = [
+        DerivedFragmentConfig(
+            fragmentName="frag",
+            fromFragment="ref",
+            refRanges=[(1, 6)]
+        )
+    ]
 
     codonalign_consensus(codonstat, quals, ref, fragments)

--- a/tests/test_fastareader.py
+++ b/tests/test_fastareader.py
@@ -10,7 +10,7 @@ def test_load_reads_sequences() -> None:
 
     data = ">seq1\nATcg\n#comment\n>seq2\nGG\n"
     sequences = fastareader.load(StringIO(data))
-    assert sequences == [
+    assert [s.model_dump() for s in sequences] == [
         {"header": "seq1", "sequence": "ATCG"},
         {"header": "seq2", "sequence": "GG"},
     ]

--- a/tests/test_sam2codfreq.py
+++ b/tests/test_sam2codfreq.py
@@ -118,7 +118,7 @@ def test_to_codon_counter_by_fragpos_and_get_codonfreq() -> None:
             "total": 3,
             "codon": "AAA",
             "count": 2,
-            "total_quality_score": 50,
+            "total_quality_score": 50.0,
         },
         {
             "gene": "geneX",
@@ -126,7 +126,7 @@ def test_to_codon_counter_by_fragpos_and_get_codonfreq() -> None:
             "total": 3,
             "codon": "CCC",
             "count": 1,
-            "total_quality_score": 20,
+            "total_quality_score": 20.0,
         },
     ]
 
@@ -197,7 +197,7 @@ def test_sam2codfreq_all() -> None:
             "total": 1,
             "codon": "AAA",
             "count": 1,
-            "total_quality_score": 30,
+            "total_quality_score": 30.0,
         }
     ]
 

--- a/tests/test_sam2codfreq.py
+++ b/tests/test_sam2codfreq.py
@@ -108,7 +108,10 @@ def test_to_codon_counter_by_fragpos_and_get_codonfreq() -> None:
     qualities = {("fragA", 1): Counter({"AAA": 50, "CCC": 20})}
     lookup = {"fragA": [("geneX", 0)]}
     rows = s2c.get_codonfreq(fragpos, qualities, lookup)
-    assert rows == [
+    assert [
+        {**row.model_dump(), "codon": row.codon.decode()}
+        for row in rows
+    ] == [
         {
             "gene": "geneX",
             "position": 1,
@@ -184,7 +187,10 @@ def test_sam2codfreq_all() -> None:
 
         rows = s2c.sam2codfreq_all("sample", (None, None), profile, workers=1)
 
-    assert rows == [
+    assert [
+        {**row.model_dump(), "codon": row.codon.decode()}
+        for row in rows
+    ] == [
         {
             "gene": "geneX",
             "position": 1,

--- a/tests/test_sam2consensus.py
+++ b/tests/test_sam2consensus.py
@@ -33,7 +33,11 @@ from codfreq.sam2consensus import (  # noqa: E402
     make_consensus,
     sam2consensus,
 )
-from codfreq.codfreq_types import NARegionConfig, Profile  # noqa: E402
+from codfreq.codfreq_types import (  # noqa: E402
+    NARegionConfig,
+    Profile,
+    RegionalConsensus,
+)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -50,18 +54,15 @@ def _cleanup_modules() -> Iterator[None]:
 def test_make_consensus_handles_gaps_and_insertions() -> None:
     """Missing bases yield gaps and insertions are appended."""
 
-    region: NARegionConfig = {
-        "name": "gag",
-        "fromFragment": "frag",
-        "refStart": 1,
-        "refEnd": 2,
-    }
+    region = NARegionConfig(
+        name="gag", fromFragment="frag", refStart=1, refEnd=2
+    )
     nacons_lookup: dict[tuple[int, int], int] = {
         (2, 0): ord("C"),
         (2, 1): ord("T"),
     }
     result = make_consensus(nacons_lookup, region)
-    assert result == {
+    assert result.model_dump() == {
         "name": "gag",
         "refStart": 1,
         "refEnd": 2,
@@ -101,14 +102,11 @@ def test_sam2consensus_keeps_frequent_insertions(
             ],
         ),
     ]
-    region: NARegionConfig = {
-        "name": "gag",
-        "fromFragment": "frag",
-        "refStart": 1,
-        "refEnd": 2,
-    }
+    region = NARegionConfig(
+        name="gag", fromFragment="frag", refStart=1, refEnd=2
+    )
     result = sam2consensus("sample.sam", region)
-    assert result == {
+    assert result.model_dump() == {
         "name": "gag",
         "refStart": 1,
         "refEnd": 2,
@@ -197,14 +195,16 @@ def test_create_untrans_region_consensus_writes_results(
         "refEnd": 2,
         "consensus": "AT",
     }
-    mock_sam2consensus.return_value = result_cons
+    mock_sam2consensus.return_value = RegionalConsensus(**result_cons)
     m = mock_open()
     with patch("codfreq.sam2consensus.open", m, create=True):
         create_untrans_region_consensus("seq1", profile)
     mock_name_bamfile.assert_called_once_with("seq1", "F1", is_trimmed=True)
     mock_sam2consensus.assert_called_once_with(
         "file.bam",
-        {"name": "R1", "fromFragment": "F1", "refStart": 1, "refEnd": 2},
+        NARegionConfig(
+            name="R1", fromFragment="F1", refStart=1, refEnd=2
+        ),
     )
     m.assert_called_once_with("seq1.untrans.json", "w")
     written = "".join(call.args[0] for call in m().write.call_args_list)


### PR DESCRIPTION
## Summary
- replace key TypedDict structures with frozen Pydantic models
- adjust alignment and consensus utilities for new models
- update tests and helpers for Pydantic-based structures

## Testing
- `flake8 .`
- `mypy codfreq tests/test_align.py tests/test_sam2codfreq.py tests/test_sam2consensus.py --ignore-missing-imports`
- `pytest --cov=codfreq --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_68995491f8c08324acd51863055e1df9